### PR TITLE
fix: Base colors fix

### DIFF
--- a/tokens/base.json
+++ b/tokens/base.json
@@ -344,7 +344,7 @@
         "type": "color"
       },
       "200": {
-        "value": "#c3c2ff",
+        "value": "#c2cfff",
         "type": "color"
       },
       "300": {
@@ -448,7 +448,7 @@
         "type": "color"
       },
       "200": {
-        "value": "#ffbdbd",
+        "value": "#ffbdd6",
         "type": "color"
       },
       "300": {


### PR DESCRIPTION
PR contains the next fixes for base colors:
- pomegranate 200, should be `ffbdd6`
- berrySmoothie200, should be `c2cfff`
