### PR TITLE
Update base text tokens

### DIFF
--- a/tokens/base.json
+++ b/tokens/base.json
@@ -885,52 +885,52 @@
   "font-family": {
     "50": {
       "value": "Roboto",
-      "type": "fontFamilies",
+      "type": "text",
       "description": "Default font-family"
     },
     "100": {
       "value": "Roboto Mono",
-      "type": "fontFamilies"
+      "type": "text"
     },
     "200": {
       "value": "Noto Sans",
-      "type": "fontFamilies"
+      "type": "text"
     }
   },
   "font-weight": {
     "300": {
-      "value": "300",
-      "type": "fontWeights"
+      "value": "Light",
+      "type": "text"
     },
     "400": {
-      "value": "400",
-      "type": "fontWeights"
+      "value": "Regular",
+      "type": "text"
     },
     "500": {
-      "value": "500",
-      "type": "fontWeights"
+      "value": "Medium",
+      "type": "text"
     },
     "700": {
-      "value": "700",
-      "type": "fontWeights"
+      "value": "Bold",
+      "type": "text"
     }
   },
   "letter-spacing": {
     "50": {
       "value": "0.4",
-      "type": "letterSpacing"
+      "type": "number"
     },
     "100": {
       "value": "0.32",
-      "type": "letterSpacing"
+      "type": "number"
     },
     "150": {
       "value": "0.24",
-      "type": "letterSpacing"
+      "type": "number"
     },
     "200": {
       "value": "0.16",
-      "type": "letterSpacing"
+      "type": "number"
     }
   },
   "shadow": {

--- a/tokens/sys/type.json
+++ b/tokens/sys/type.json
@@ -2,15 +2,15 @@
   "font-family": {
     "default": {
       "value": "{font-family.50}",
-      "type": "fontFamilies"
+      "type": "text"
     },
     "mono": {
       "value": "{font-family.100}",
-      "type": "fontFamilies"
+      "type": "text"
     },
     "global": {
       "value": "{font-family.200}",
-      "type": "fontFamilies"
+      "type": "text"
     }
   },
   "font-size": {
@@ -132,19 +132,19 @@
   "font-weight": {
     "light": {
       "value": "{font-weight.300}",
-      "type": "fontWeights"
+      "type": "text"
     },
     "normal": {
       "value": "{font-weight.400}",
-      "type": "fontWeights"
+      "type": "text"
     },
     "medium": {
       "value": "{font-weight.500}",
-      "type": "fontWeights"
+      "type": "text"
     },
     "bold": {
       "value": "{font-weight.700}",
-      "type": "fontWeights"
+      "type": "text"
     }
   },
   "type": {


### PR DESCRIPTION
Changed types to 'number' or 'string'
FontWeight uses strings instead of numbers ('Bold' instead of '700')

Does not include lineHeight changes