### PR TITLE
feat: Add new color palette

### DIFF
--- a/tokens/base.json
+++ b/tokens/base.json
@@ -1,705 +1,1141 @@
 {
   "palette": {
-    "cinnamon": {
+    "red": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9759, 0.0173, 51.968],
+          "alpha": 1,
+          "hex": "#fff4ed"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.39) | 3:1 pair: 500 (contrast: 3.17) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9519, 0.0325, 41.292],
+          "alpha": 1,
+          "hex": "#ffe9df"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.00) | 3:1 pair: 600 (contrast: 5.00) | Passes on: black"
+      },
       "100": {
-        "value": "#ffefee",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9297, 0.047, 34.89],
+          "alpha": 1,
+          "hex": "#ffddd3"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 600 (contrast: 4.65) | Passes on: black"
       },
       "200": {
-        "value": "#FCC9C5",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.864, 0.094, 31.01],
+          "alpha": 1,
+          "hex": "#ffbcad"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.10) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
       },
       "300": {
-        "value": "#ff867d",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.795, 0.149, 28.619],
+          "alpha": 1,
+          "hex": "#ff9687"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.56) | 3:1 pair: 700 (contrast: 3.95) | Passes on: black"
       },
       "400": {
-        "value": "#ff5347",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.729, 0.213, 29.281],
+          "alpha": 1,
+          "hex": "#ff6e5c"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.36) | 3:1 pair: 800 (contrast: 4.26) | Passes on: black"
       },
       "500": {
-        "value": "#de2e21",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.664, 0.234, 28.5],
+          "alpha": 1,
+          "hex": "#ff3e33"
+        },
+        "description": "3:1 pair: 900 (contrast: 4.13) | Passes on: black"
       },
       "600": {
-        "value": "#a31b12",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.535, 0.221, 26.8],
+          "alpha": 1,
+          "hex": "#cf0014"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.458, 0.191, 26],
+          "alpha": 1,
+          "hex": "#a80011"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.372, 0.158, 25.5],
+          "alpha": 1,
+          "hex": "#80000a"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.304, 0.112, 25],
+          "alpha": 1,
+          "hex": "#5b0a0e"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.251, 0.073, 25.5],
+          "alpha": 1,
+          "hex": "#3e100e"
+        },
+        "description": "Passes on: white"
       }
     },
-    "peach": {
+    "orange": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.977, 0.033, 88.018],
+          "alpha": 1,
+          "hex": "#fff7df"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.21) | 3:1 pair: 600 (contrast: 5.21) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9549, 0.0549, 82.559],
+          "alpha": 1,
+          "hex": "#ffedc7"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.88) | 3:1 pair: 600 (contrast: 4.88) | Passes on: black"
+      },
       "100": {
-        "value": "#fff3f0",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9297, 0.0771, 77.91],
+          "alpha": 1,
+          "hex": "#ffe2ae"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.50) | 3:1 pair: 600 (contrast: 4.50) | Passes on: black"
       },
       "200": {
-        "value": "#ffc2b3",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.884, 0.116, 72.291],
+          "alpha": 1,
+          "hex": "#ffcc80"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 4.74) | 3:1 pair: 600 (contrast: 3.87) | Passes on: black"
       },
       "300": {
-        "value": "#ff957a",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.815, 0.174, 65.612],
+          "alpha": 1,
+          "hex": "#ffa92f"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.42) | 3:1 pair: 700 (contrast: 3.70) | Passes on: black"
       },
       "400": {
-        "value": "#ff643d",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.726, 0.185, 52.588],
+          "alpha": 1,
+          "hex": "#fd7e01"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 4.73) | 3:1 pair: 800 (contrast: 3.88) | Passes on: black"
       },
       "500": {
-        "value": "#de4721",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.678, 0.21, 40.37],
+          "alpha": 1,
+          "hex": "#fc5b04"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.85) | Passes on: black"
       },
       "600": {
-        "value": "#b53413",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.538, 0.188, 39.18],
+          "alpha": 1,
+          "hex": "#c23400"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.488, 0.16, 38.07],
+          "alpha": 1,
+          "hex": "#a63200"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.394, 0.121, 37.21],
+          "alpha": 1,
+          "hex": "#79260b"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.341, 0.093, 36.41],
+          "alpha": 1,
+          "hex": "#5f2211"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.283, 0.061, 36.2],
+          "alpha": 1,
+          "hex": "#431d13"
+        },
+        "description": "Passes on: white"
       }
     },
-    "chili-mango": {
+    "amber": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.978, 0.025, 95.3],
+          "alpha": 1,
+          "hex": "#fdf8e5"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.11) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.957, 0.095, 100.2],
+          "alpha": 1,
+          "hex": "#fff3a8"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.83) | 3:1 pair: 600 (contrast: 4.83) | Passes on: black"
+      },
       "100": {
-        "value": "#ffe6d9",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9341, 0.1327, 99.571],
+          "alpha": 1,
+          "hex": "#feeb7d"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.51) | 3:1 pair: 600 (contrast: 4.51) | Passes on: black"
       },
       "200": {
-        "value": "#ffc7ab",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.919, 0.155, 99.7],
+          "alpha": 1,
+          "hex": "#fde65e"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.42) | 3:1 pair: 600 (contrast: 4.31) | Passes on: black"
       },
       "300": {
-        "value": "#ff9b69",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.843, 0.175, 85.2],
+          "alpha": 1,
+          "hex": "#ffc100"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.19) | 3:1 pair: 700 (contrast: 4.18) | Passes on: black"
       },
       "400": {
-        "value": "#ff671b",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.762, 0.182, 70.69],
+          "alpha": 1,
+          "hex": "#f89900"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 3.85) | Passes on: black"
       },
       "500": {
-        "value": "#e04b00",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.6682, 0.1876, 55.52],
+          "alpha": 1,
+          "hex": "#e76d00"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.54) | Passes on: black"
       },
       "600": {
-        "value": "#a33600",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.5381, 0.1616, 50.073],
+          "alpha": 1,
+          "hex": "#b44900"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.483, 0.142, 48.997],
+          "alpha": 1,
+          "hex": "#9b3e00"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.432, 0.129, 46.202],
+          "alpha": 1,
+          "hex": "#863200"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.358, 0.093, 48.903],
+          "alpha": 1,
+          "hex": "#622a03"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.305, 0.061, 49.636],
+          "alpha": 1,
+          "hex": "#472510"
+        },
+        "description": "Passes on: white"
       }
     },
-    "cantaloupe": {
+    "green": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.985, 0.025, 145.2],
+          "alpha": 1,
+          "hex": "#f0fff0"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.20) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.963, 0.056, 145.655],
+          "alpha": 1,
+          "hex": "#dcfedd"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.93) | 3:1 pair: 600 (contrast: 4.93) | Passes on: black"
+      },
       "100": {
-        "value": "#ffeed9",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.931, 0.088, 146.109],
+          "alpha": 1,
+          "hex": "#c3f9c5"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.53) | 3:1 pair: 600 (contrast: 4.53) | Passes on: black"
       },
       "200": {
-        "value": "#fcd49f",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.87, 0.135, 146.564],
+          "alpha": 1,
+          "hex": "#97ec9f"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.05) | 3:1 pair: 600 (contrast: 3.81) | Passes on: black"
       },
       "300": {
-        "value": "#ffbc63",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.792, 0.158, 147.018],
+          "alpha": 1,
+          "hex": "#6ed67d"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.41) | 3:1 pair: 700 (contrast: 3.94) | Passes on: black"
       },
       "400": {
-        "value": "#ffa126",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.725, 0.178, 147.473],
+          "alpha": 1,
+          "hex": "#45c360"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.53) | 3:1 pair: 800 (contrast: 4.31) | Passes on: black"
       },
       "500": {
-        "value": "#f38b00",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.638, 0.192, 147.927],
+          "alpha": 1,
+          "hex": "#00a93e"
+        },
+        "description": "3:1 pair: 900 (contrast: 4.01) | Passes on: black"
       },
       "600": {
-        "value": "#c06c00",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.507, 0.175, 148.382],
+          "alpha": 1,
+          "hex": "#007e1e"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.443, 0.156, 148.836],
+          "alpha": 1,
+          "hex": "#006917"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.372, 0.125, 149.291],
+          "alpha": 1,
+          "hex": "#005114"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.312, 0.095, 149.745],
+          "alpha": 1,
+          "hex": "#003d13"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.247, 0.066, 150.2],
+          "alpha": 1,
+          "hex": "#01290f"
+        },
+        "description": "Passes on: white"
       }
     },
-    "sour-lemon": {
+    "teal": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9717, 0.0389, 199.269],
+          "alpha": 1,
+          "hex": "#d8feff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.17) | 3:1 pair: 500 (contrast: 3.43) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.961, 0.044, 203.92],
+          "alpha": 1,
+          "hex": "#d1fbff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.01) | 3:1 pair: 500 (contrast: 3.33) | Passes on: black"
+      },
       "100": {
-        "value": "#fff9e6",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.928, 0.058, 204.1],
+          "alpha": 1,
+          "hex": "#baf3f9"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.56) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
       },
       "200": {
-        "value": "#ffecab",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.858, 0.075, 204.3],
+          "alpha": 1,
+          "hex": "#94dfe7"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 4.95) | 3:1 pair: 600 (contrast: 3.69) | Passes on: black"
       },
       "300": {
-        "value": "#ffda61",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.784, 0.087, 204.89],
+          "alpha": 1,
+          "hex": "#70c9d3"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.16) | 3:1 pair: 700 (contrast: 3.89) | Passes on: black"
       },
       "400": {
-        "value": "#ffc629",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.718, 0.102, 205.12],
+          "alpha": 1,
+          "hex": "#44b6c2"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.20) | 3:1 pair: 800 (contrast: 4.10) | Passes on: black"
       },
       "500": {
-        "value": "#ebb400",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.606, 0.115, 205.31],
+          "alpha": 1,
+          "hex": "#0095a3"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.40) | Passes on: black"
       },
       "600": {
-        "value": "#bd9100",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.508, 0.107, 206.42],
+          "alpha": 1,
+          "hex": "#007684"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.441, 0.093, 207.51],
+          "alpha": 1,
+          "hex": "#00606d"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.376, 0.079, 208.44],
+          "alpha": 1,
+          "hex": "#004c57"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.318, 0.062, 209.18],
+          "alpha": 1,
+          "hex": "#003a43"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.253, 0.041, 210.53],
+          "alpha": 1,
+          "hex": "#03272d"
+        },
+        "description": "Passes on: white"
       }
     },
-    "juicy-pear": {
+    "blue": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.981, 0.014, 218.951],
+          "alpha": 1,
+          "hex": "#effbff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.38) | 3:1 pair: 500 (contrast: 3.49) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.959, 0.026, 231.237],
+          "alpha": 1,
+          "hex": "#e1f5ff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.06) | 3:1 pair: 500 (contrast: 3.27) | Passes on: black"
+      },
       "100": {
-        "value": "#f7fae6",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.931, 0.04, 240.111],
+          "alpha": 1,
+          "hex": "#d1edff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
       },
       "200": {
-        "value": "#e2f391",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.8619, 0.0786, 247.216],
+          "alpha": 1,
+          "hex": "#a8d7ff"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 4.67) | 3:1 pair: 600 (contrast: 3.75) | Passes on: black"
       },
       "300": {
-        "value": "#c4de40",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.7908, 0.1195, 250.418],
+          "alpha": 1,
+          "hex": "#7ec0ff"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 4.78) | 3:1 pair: 700 (contrast: 3.68) | Passes on: black"
       },
       "400": {
-        "value": "#a8c224",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.714, 0.166, 252.066],
+          "alpha": 1,
+          "hex": "#4aa6ff"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.17) | 3:1 pair: 800 (contrast: 3.61) | Passes on: black"
       },
       "500": {
-        "value": "#8ea618",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.622, 0.196, 255.3],
+          "alpha": 1,
+          "hex": "#1984f9"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.57) | Passes on: black"
       },
       "600": {
-        "value": "#687818",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.518, 0.181, 255.4],
+          "alpha": 1,
+          "hex": "#0065cd"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.466, 0.156, 255.5],
+          "alpha": 1,
+          "hex": "#0057ae"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.404, 0.123, 257.4],
+          "alpha": 1,
+          "hex": "#154789"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.315, 0.105, 261.1],
+          "alpha": 1,
+          "hex": "#0f2e66"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.245, 0.075, 254.5],
+          "alpha": 1,
+          "hex": "#022043"
+        },
+        "description": "Passes on: white"
       }
     },
-    "kiwi": {
+    "purple": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.976, 0.018, 315.668],
+          "alpha": 1,
+          "hex": "#fcf4ff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.32) | 3:1 pair: 500 (contrast: 3.54) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.959, 0.032, 316.515],
+          "alpha": 1,
+          "hex": "#faebff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.04) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
+      },
       "100": {
-        "value": "#ecfcd7",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.929, 0.058, 317.538],
+          "alpha": 1,
+          "hex": "#f8dcff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.57) | 3:1 pair: 500 (contrast: 3.04) | Passes on: black"
       },
       "200": {
-        "value": "#caf593",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.868, 0.1, 312.379],
+          "alpha": 1,
+          "hex": "#eac1ff"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.06) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
       },
       "300": {
-        "value": "#a7e05c",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.808, 0.131, 311.7],
+          "alpha": 1,
+          "hex": "#dca7fe"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.43) | 3:1 pair: 700 (contrast: 4.09) | Passes on: black"
       },
       "400": {
-        "value": "#77bc1f",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.724, 0.152, 312.5],
+          "alpha": 1,
+          "hex": "#c687ea"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.15) | 3:1 pair: 800 (contrast: 3.98) | Passes on: black"
       },
       "500": {
-        "value": "#609915",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.628, 0.168, 312.7],
+          "alpha": 1,
+          "hex": "#ab65d0"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.51) | Passes on: black"
       },
       "600": {
-        "value": "#537824",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.529, 0.157, 312.4],
+          "alpha": 1,
+          "hex": "#8a4bab"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.455, 0.135, 312.5],
+          "alpha": 1,
+          "hex": "#703b8b"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.385, 0.112, 312.4],
+          "alpha": 1,
+          "hex": "#582e6e"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.315, 0.086, 311.1],
+          "alpha": 1,
+          "hex": "#3f2351"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.255, 0.065, 312.5],
+          "alpha": 1,
+          "hex": "#2d1839"
+        },
+        "description": "Passes on: white"
       }
     },
-    "green-apple": {
+    "pink": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.974, 0.028, 329.217],
+          "alpha": 1,
+          "hex": "#fff0ff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.36) | 3:1 pair: 500 (contrast: 3.37) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.9577, 0.047, 329.385],
+          "alpha": 1,
+          "hex": "#ffe6ff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.07) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
+      },
       "100": {
-        "value": "#ebfff0",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.94, 0.067, 329.515],
+          "alpha": 1,
+          "hex": "#ffdcff"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.78) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
       },
       "200": {
-        "value": "#acf5be",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.887, 0.103, 327.5],
+          "alpha": 1,
+          "hex": "#ffc2fd"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.15) | 3:1 pair: 600 (contrast: 4.00) | Passes on: black"
       },
       "300": {
-        "value": "#5fe380",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.808, 0.124, 333.7],
+          "alpha": 1,
+          "hex": "#f1a1e2"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 5.68) | 3:1 pair: 700 (contrast: 3.92) | Passes on: black"
       },
       "400": {
-        "value": "#43c463",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.726, 0.145, 338.9],
+          "alpha": 1,
+          "hex": "#e180c5"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 4.19) | Passes on: black"
       },
       "500": {
-        "value": "#319c4c",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.637, 0.148, 338.9],
+          "alpha": 1,
+          "hex": "#c464a9"
+        },
+        "description": "3:1 pair: 900 (contrast: 3.63) | Passes on: black"
       },
       "600": {
-        "value": "#217a37",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.525, 0.141, 345.2],
+          "alpha": 1,
+          "hex": "#a1437c"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.464, 0.124, 348.5],
+          "alpha": 1,
+          "hex": "#893765"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.373, 0.103, 350],
+          "alpha": 1,
+          "hex": "#662548"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.317, 0.082, 350.5],
+          "alpha": 1,
+          "hex": "#501e37"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.267, 0.052, 350.1],
+          "alpha": 1,
+          "hex": "#381a29"
+        },
+        "description": "Passes on: white"
       }
     },
-    "watermelon": {
+    "slate": {
+      "25": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.985, 0.003, 255.5],
+          "alpha": 1,
+          "hex": "#f9fafc"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.50) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
+      },
+      "50": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.969, 0.005, 255.5],
+          "alpha": 1,
+          "hex": "#f3f5f8"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 5.25) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
+      },
       "100": {
-        "value": "#ebfdf8",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.944, 0.008, 255.5],
+          "alpha": 1,
+          "hex": "#e9edf2"
+        },
+        "$description": "4.5:1 pair: 600 (contrast: 4.87) | 3:1 pair: 600 (contrast: 4.87) | Passes on: black"
+      },
+      "150": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.908, 0.012, 255.5],
+          "alpha": 1,
+          "hex": "#dbe1e9"
+        },
+        "description": "Passes on: black"
       },
       "200": {
-        "value": "#b7edde",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.871, 0.015, 255.5],
+          "alpha": 1,
+          "hex": "#ced5df"
+        },
+        "$description": "4.5:1 pair: 700 (contrast: 5.03) | 3:1 pair: 600 (contrast: 3.89) | Passes on: black"
+      },
+      "250": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.835, 0.018, 255.5],
+          "alpha": 1,
+          "hex": "#c1cad5"
+        },
+        "description": "Passes on: black"
       },
       "300": {
-        "value": "#65ccaf",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.803, 0.022, 255.5],
+          "alpha": 1,
+          "hex": "#b6c0cd"
+        },
+        "$description": "4.5:1 pair: 800 (contrast: 6.09) | 3:1 pair: 700 (contrast: 4.02) | Passes on: black"
       },
       "400": {
-        "value": "#12a67c",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.72, 0.025, 255.5],
+          "alpha": 1,
+          "hex": "#9ba6b4"
+        },
+        "$description": "4.5:1 pair: 900 (contrast: 7.15) | 3:1 pair: 800 (contrast: 4.54) | Passes on: black"
       },
       "500": {
-        "value": "#0c7a5b",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.63, 0.028, 255.5],
+          "alpha": 1,
+          "hex": "#7e8a9a"
+        },
+        "description": "3:1 pair: 900 (contrast: 5.07) | Passes on: black"
       },
       "600": {
-        "value": "#00573e",
-        "type": "color"
-      }
-    },
-    "jewel": {
-      "100": {
-        "value": "#ebfdff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#acecf3",
-        "type": "color"
-      },
-      "300": {
-        "value": "#44c8d7",
-        "type": "color"
-      },
-      "400": {
-        "value": "#1ea4b3",
-        "type": "color"
-      },
-      "500": {
-        "value": "#1a818c",
-        "type": "color"
-      },
-      "600": {
-        "value": "#156973",
-        "type": "color"
-      }
-    },
-    "toothpaste": {
-      "100": {
-        "value": "#d7f1fc",
-        "type": "color"
-      },
-      "200": {
-        "value": "#99e0ff",
-        "type": "color"
-      },
-      "300": {
-        "value": "#40b4e5",
-        "type": "color"
-      },
-      "400": {
-        "value": "#1894c9",
-        "type": "color"
-      },
-      "500": {
-        "value": "#0271a1",
-        "type": "color"
-      },
-      "600": {
-        "value": "#005B82",
-        "type": "color"
-      }
-    },
-    "blueberry": {
-      "100": {
-        "value": "#D7EAFC",
-        "type": "color"
-      },
-      "200": {
-        "value": "#A6D2FF",
-        "type": "color"
-      },
-      "300": {
-        "value": "#40A0FF",
-        "type": "color"
-      },
-      "400": {
-        "value": "#0875E1",
-        "type": "color"
-      },
-      "500": {
-        "value": "#005cb9",
-        "type": "color"
-      },
-      "600": {
-        "value": "#004387",
-        "type": "color"
-      }
-    },
-    "plum": {
-      "100": {
-        "value": "#e6f1ff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#A6CDFF",
-        "type": "color"
-      },
-      "300": {
-        "value": "#529bfa",
-        "type": "color"
-      },
-      "400": {
-        "value": "#3881E1",
-        "type": "color"
-      },
-      "500": {
-        "value": "#3166ab",
-        "type": "color"
-      },
-      "600": {
-        "value": "#264a7a",
-        "type": "color"
-      }
-    },
-    "berry-smoothie": {
-      "100": {
-        "value": "#e8edff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#c2cfff",
-        "type": "color"
-      },
-      "300": {
-        "value": "#7891FF",
-        "type": "color"
-      },
-      "400": {
-        "value": "#5E77E6",
-        "type": "color"
-      },
-      "500": {
-        "value": "#4b5eb3",
-        "type": "color"
-      },
-      "600": {
-        "value": "#3b4987",
-        "type": "color"
-      }
-    },
-    "blackberry": {
-      "100": {
-        "value": "#f0f0ff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#c3c2ff",
-        "type": "color"
-      },
-      "300": {
-        "value": "#8483e6",
-        "type": "color"
-      },
-      "400": {
-        "value": "#5c59e6",
-        "type": "color"
-      },
-      "500": {
-        "value": "#413fcc",
-        "type": "color"
-      },
-      "600": {
-        "value": "#2e2d91",
-        "type": "color"
-      }
-    },
-    "island-punch": {
-      "100": {
-        "value": "#f5f0ff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#d2befa",
-        "type": "color"
-      },
-      "300": {
-        "value": "#a88ae6",
-        "type": "color"
-      },
-      "400": {
-        "value": "#8660d1",
-        "type": "color"
-      },
-      "500": {
-        "value": "#6345a1",
-        "type": "color"
-      },
-      "600": {
-        "value": "#503882",
-        "type": "color"
-      }
-    },
-    "grape-soda": {
-      "100": {
-        "value": "#feebff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#fac0ff",
-        "type": "color"
-      },
-      "300": {
-        "value": "#de8ae6",
-        "type": "color"
-      },
-      "400": {
-        "value": "#c860d1",
-        "type": "color"
-      },
-      "500": {
-        "value": "#97499e",
-        "type": "color"
-      },
-      "600": {
-        "value": "#7C3882",
-        "type": "color"
-      }
-    },
-    "pomegranate": {
-      "100": {
-        "value": "#ffebf3",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ffbdd6",
-        "type": "color"
-      },
-      "300": {
-        "value": "#ff5c9a",
-        "type": "color"
-      },
-      "400": {
-        "value": "#f31167",
-        "type": "color"
-      },
-      "500": {
-        "value": "#c70550",
-        "type": "color"
-      },
-      "600": {
-        "value": "#99003a",
-        "type": "color"
-      }
-    },
-    "fruit-punch": {
-      "100": {
-        "value": "#FFEEEE",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ffbdbd",
-        "type": "color"
-      },
-      "300": {
-        "value": "#FF7E7E",
-        "type": "color"
-      },
-      "400": {
-        "value": "#ff4c4c",
-        "type": "color"
-      },
-      "500": {
-        "value": "#e12f2f",
-        "type": "color"
-      },
-      "600": {
-        "value": "#b82828",
-        "type": "color"
-      }
-    },
-    "root-beer": {
-      "100": {
-        "value": "#faf3f0",
-        "type": "color"
-      },
-      "200": {
-        "value": "#EBD7CF",
-        "type": "color"
-      },
-      "300": {
-        "value": "#dcbbad",
-        "type": "color"
-      },
-      "400": {
-        "value": "#ba9a8c",
-        "type": "color"
-      },
-      "500": {
-        "value": "#8C7266",
-        "type": "color"
-      },
-      "600": {
-        "value": "#664d42",
-        "type": "color"
-      }
-    },
-    "toasted-marshmallow": {
-      "100": {
-        "value": "#fdf6e6",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ebd6a9",
-        "type": "color"
-      },
-      "300": {
-        "value": "#e6bf6c",
-        "type": "color"
-      },
-      "400": {
-        "value": "#CC9E3B",
-        "type": "color"
-      },
-      "500": {
-        "value": "#b37f10",
-        "type": "color"
-      },
-      "600": {
-        "value": "#8C6000",
-        "type": "color"
-      }
-    },
-    "coconut": {
-      "100": {
-        "value": "#F0EEEE",
-        "type": "color"
-      },
-      "200": {
-        "value": "#e3dfdf",
-        "type": "color"
-      },
-      "300": {
-        "value": "#d1cbcc",
-        "type": "color"
-      },
-      "400": {
-        "value": "#b3acac",
-        "type": "color"
-      },
-      "500": {
-        "value": "#9e9595",
-        "type": "color"
-      },
-      "600": {
-        "value": "#8F8687",
-        "type": "color"
-      }
-    },
-    "cappuccino": {
-      "100": {
-        "value": "#7A7374",
-        "type": "color"
-      },
-      "200": {
-        "value": "#706869",
-        "type": "color"
-      },
-      "300": {
-        "value": "#5E5757",
-        "type": "color"
-      },
-      "400": {
-        "value": "#4A4242",
-        "type": "color"
-      },
-      "500": {
-        "value": "#352f2f",
-        "type": "color"
-      },
-      "600": {
-        "value": "#231f20",
-        "type": "color"
-      }
-    },
-    "licorice": {
-      "100": {
-        "value": "#A1AAB3",
-        "type": "color"
-      },
-      "200": {
-        "value": "#7b858f",
-        "type": "color"
-      },
-      "300": {
-        "value": "#5E6A75",
-        "type": "color"
-      },
-      "400": {
-        "value": "#4a5561",
-        "type": "color"
-      },
-      "500": {
-        "value": "#333d47",
-        "type": "color"
-      },
-      "600": {
-        "value": "#1f262e",
-        "type": "color"
-      }
-    },
-    "soap": {
-      "100": {
-        "value": "#f6f7f8",
-        "type": "color"
-      },
-      "200": {
-        "value": "#F0F1F2",
-        "type": "color"
-      },
-      "300": {
-        "value": "#e8ebed",
-        "type": "color"
-      },
-      "400": {
-        "value": "#DFE2E6",
-        "type": "color"
-      },
-      "500": {
-        "value": "#ced3d9",
-        "type": "color"
-      },
-      "600": {
-        "value": "#B9C0C7",
-        "type": "color"
-      }
-    },
-    "french-vanilla": {
-      "100": {
-        "value": "#ffffff",
-        "type": "color"
-      },
-      "200": {
-        "value": "#ebebeb",
-        "type": "color"
-      },
-      "300": {
-        "value": "#d4d4d4",
-        "type": "color"
-      },
-      "400": {
-        "value": "#bdbdbd",
-        "type": "color"
-      },
-      "500": {
-        "value": "#a6a6a6",
-        "type": "color"
-      },
-      "600": {
-        "value": "#8f8f8f",
-        "type": "color"
-      }
-    },
-    "black-pepper": {
-      "100": {
-        "value": "#787878",
-        "type": "color"
-      },
-      "200": {
-        "value": "#616161",
-        "type": "color"
-      },
-      "300": {
-        "value": "#494949",
-        "type": "color"
-      },
-      "400": {
-        "value": "#333333",
-        "type": "color"
-      },
-      "500": {
-        "value": "#1e1e1e",
-        "type": "color"
-      },
-      "600": {
-        "value": "#000000",
-        "type": "color"
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.51, 0.025, 255.5],
+          "alpha": 1,
+          "hex": "#5d6775"
+        },
+        "description": "Passes on: white"
+      },
+      "700": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.45, 0.022, 255.5],
+          "alpha": 1,
+          "hex": "#4d5662"
+        },
+        "description": "Passes on: white"
+      },
+      "800": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.351, 0.018, 255.5],
+          "alpha": 1,
+          "hex": "#353b44"
+        },
+        "description": "Passes on: white"
+      },
+      "850": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.29, 0.015, 255.5],
+          "alpha": 1,
+          "hex": "#262c33"
+        },
+        "description": "Passes on: white"
+      },
+      "900": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.21, 0.012, 255.5],
+          "alpha": 1,
+          "hex": "#15191e"
+        },
+        "description": "Passes on: white"
+      },
+      "950": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.15, 0.008, 255.5],
+          "alpha": 1,
+          "hex": "#090b0f"
+        },
+        "description": "Passes on: white"
+      },
+      "975": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "oklch",
+          "components": [0.11, 0.006, 255.5],
+          "alpha": 1,
+          "hex": "#040406"
+        },
+        "description": "Passes on: white"
       }
     }
   },
@@ -1068,36 +1504,6 @@
         "blur": {
           "value": "48",
           "type": "number"
-        }
-      }
-    }
-  },
-  "extended": {
-    "palette": {
-      "dragon-fruit": {
-        "100": {
-          "value": "#FBF1FF",
-          "type": "color"
-        },
-        "200": {
-          "value": "#EFD3FF",
-          "type": "color"
-        },
-        "300": {
-          "value": "#BE61F6",
-          "type": "color"
-        },
-        "400": {
-          "value": "#8C17D2",
-          "type": "color"
-        },
-        "500": {
-          "value": "#6B11A3",
-          "type": "color"
-        },
-        "600": {
-          "value": "#4A0D71",
-          "type": "color"
         }
       }
     }

--- a/tokens/base.json
+++ b/tokens/base.json
@@ -2,68 +2,68 @@
   "palette": {
     "red": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9759, 0.0173, 51.968],
           "alpha": 1,
           "hex": "#fff4ed"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.39) | 3:1 pair: 500 (contrast: 3.17) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.39) | 3:1 pair: 500 (contrast: 3.17) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9519, 0.0325, 41.292],
           "alpha": 1,
           "hex": "#ffe9df"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.00) | 3:1 pair: 600 (contrast: 5.00) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.00) | 3:1 pair: 600 (contrast: 5.00) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9297, 0.047, 34.89],
           "alpha": 1,
           "hex": "#ffddd3"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 600 (contrast: 4.65) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 600 (contrast: 4.65) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.864, 0.094, 31.01],
           "alpha": 1,
           "hex": "#ffbcad"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.10) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.10) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.795, 0.149, 28.619],
           "alpha": 1,
           "hex": "#ff9687"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.56) | 3:1 pair: 700 (contrast: 3.95) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.56) | 3:1 pair: 700 (contrast: 3.95) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.729, 0.213, 29.281],
           "alpha": 1,
           "hex": "#ff6e5c"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.36) | 3:1 pair: 800 (contrast: 4.26) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.36) | 3:1 pair: 800 (contrast: 4.26) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.664, 0.234, 28.5],
           "alpha": 1,
@@ -72,8 +72,8 @@
         "description": "3:1 pair: 900 (contrast: 4.13) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.535, 0.221, 26.8],
           "alpha": 1,
@@ -82,8 +82,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.458, 0.191, 26],
           "alpha": 1,
@@ -92,8 +92,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.372, 0.158, 25.5],
           "alpha": 1,
@@ -102,8 +102,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.304, 0.112, 25],
           "alpha": 1,
@@ -112,8 +112,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.251, 0.073, 25.5],
           "alpha": 1,
@@ -124,68 +124,68 @@
     },
     "orange": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.977, 0.033, 88.018],
           "alpha": 1,
           "hex": "#fff7df"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.21) | 3:1 pair: 600 (contrast: 5.21) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.21) | 3:1 pair: 600 (contrast: 5.21) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9549, 0.0549, 82.559],
           "alpha": 1,
           "hex": "#ffedc7"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.88) | 3:1 pair: 600 (contrast: 4.88) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.88) | 3:1 pair: 600 (contrast: 4.88) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9297, 0.0771, 77.91],
           "alpha": 1,
           "hex": "#ffe2ae"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.50) | 3:1 pair: 600 (contrast: 4.50) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.50) | 3:1 pair: 600 (contrast: 4.50) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.884, 0.116, 72.291],
           "alpha": 1,
           "hex": "#ffcc80"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 4.74) | 3:1 pair: 600 (contrast: 3.87) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 4.74) | 3:1 pair: 600 (contrast: 3.87) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.815, 0.174, 65.612],
           "alpha": 1,
           "hex": "#ffa92f"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.42) | 3:1 pair: 700 (contrast: 3.70) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.42) | 3:1 pair: 700 (contrast: 3.70) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.726, 0.185, 52.588],
           "alpha": 1,
           "hex": "#fd7e01"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 4.73) | 3:1 pair: 800 (contrast: 3.88) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 4.73) | 3:1 pair: 800 (contrast: 3.88) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.678, 0.21, 40.37],
           "alpha": 1,
@@ -194,8 +194,8 @@
         "description": "3:1 pair: 900 (contrast: 3.85) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.538, 0.188, 39.18],
           "alpha": 1,
@@ -204,8 +204,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.488, 0.16, 38.07],
           "alpha": 1,
@@ -214,8 +214,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.394, 0.121, 37.21],
           "alpha": 1,
@@ -224,8 +224,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.341, 0.093, 36.41],
           "alpha": 1,
@@ -234,8 +234,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.283, 0.061, 36.2],
           "alpha": 1,
@@ -246,68 +246,68 @@
     },
     "amber": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.978, 0.025, 95.3],
           "alpha": 1,
           "hex": "#fdf8e5"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.11) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.11) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.957, 0.095, 100.2],
           "alpha": 1,
           "hex": "#fff3a8"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.83) | 3:1 pair: 600 (contrast: 4.83) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.83) | 3:1 pair: 600 (contrast: 4.83) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9341, 0.1327, 99.571],
           "alpha": 1,
           "hex": "#feeb7d"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.51) | 3:1 pair: 600 (contrast: 4.51) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.51) | 3:1 pair: 600 (contrast: 4.51) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.919, 0.155, 99.7],
           "alpha": 1,
           "hex": "#fde65e"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.42) | 3:1 pair: 600 (contrast: 4.31) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.42) | 3:1 pair: 600 (contrast: 4.31) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.843, 0.175, 85.2],
           "alpha": 1,
           "hex": "#ffc100"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.19) | 3:1 pair: 700 (contrast: 4.18) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.19) | 3:1 pair: 700 (contrast: 4.18) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.762, 0.182, 70.69],
           "alpha": 1,
           "hex": "#f89900"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 3.85) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 3.85) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.6682, 0.1876, 55.52],
           "alpha": 1,
@@ -316,8 +316,8 @@
         "description": "3:1 pair: 900 (contrast: 3.54) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.5381, 0.1616, 50.073],
           "alpha": 1,
@@ -326,8 +326,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.483, 0.142, 48.997],
           "alpha": 1,
@@ -336,8 +336,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.432, 0.129, 46.202],
           "alpha": 1,
@@ -346,8 +346,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.358, 0.093, 48.903],
           "alpha": 1,
@@ -356,8 +356,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.305, 0.061, 49.636],
           "alpha": 1,
@@ -368,68 +368,68 @@
     },
     "green": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.985, 0.025, 145.2],
           "alpha": 1,
           "hex": "#f0fff0"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.20) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.20) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.963, 0.056, 145.655],
           "alpha": 1,
           "hex": "#dcfedd"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.93) | 3:1 pair: 600 (contrast: 4.93) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.93) | 3:1 pair: 600 (contrast: 4.93) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.931, 0.088, 146.109],
           "alpha": 1,
           "hex": "#c3f9c5"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.53) | 3:1 pair: 600 (contrast: 4.53) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.53) | 3:1 pair: 600 (contrast: 4.53) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.87, 0.135, 146.564],
           "alpha": 1,
           "hex": "#97ec9f"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.05) | 3:1 pair: 600 (contrast: 3.81) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.05) | 3:1 pair: 600 (contrast: 3.81) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.792, 0.158, 147.018],
           "alpha": 1,
           "hex": "#6ed67d"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.41) | 3:1 pair: 700 (contrast: 3.94) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.41) | 3:1 pair: 700 (contrast: 3.94) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.725, 0.178, 147.473],
           "alpha": 1,
           "hex": "#45c360"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.53) | 3:1 pair: 800 (contrast: 4.31) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.53) | 3:1 pair: 800 (contrast: 4.31) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.638, 0.192, 147.927],
           "alpha": 1,
@@ -438,8 +438,8 @@
         "description": "3:1 pair: 900 (contrast: 4.01) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.507, 0.175, 148.382],
           "alpha": 1,
@@ -448,8 +448,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.443, 0.156, 148.836],
           "alpha": 1,
@@ -458,8 +458,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.372, 0.125, 149.291],
           "alpha": 1,
@@ -468,8 +468,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.312, 0.095, 149.745],
           "alpha": 1,
@@ -478,8 +478,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.247, 0.066, 150.2],
           "alpha": 1,
@@ -490,68 +490,68 @@
     },
     "teal": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9717, 0.0389, 199.269],
           "alpha": 1,
           "hex": "#d8feff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.17) | 3:1 pair: 500 (contrast: 3.43) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.17) | 3:1 pair: 500 (contrast: 3.43) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.961, 0.044, 203.92],
           "alpha": 1,
           "hex": "#d1fbff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.01) | 3:1 pair: 500 (contrast: 3.33) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.01) | 3:1 pair: 500 (contrast: 3.33) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.928, 0.058, 204.1],
           "alpha": 1,
           "hex": "#baf3f9"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.56) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.56) | 3:1 pair: 500 (contrast: 3.03) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.858, 0.075, 204.3],
           "alpha": 1,
           "hex": "#94dfe7"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 4.95) | 3:1 pair: 600 (contrast: 3.69) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 4.95) | 3:1 pair: 600 (contrast: 3.69) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.784, 0.087, 204.89],
           "alpha": 1,
           "hex": "#70c9d3"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.16) | 3:1 pair: 700 (contrast: 3.89) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.16) | 3:1 pair: 700 (contrast: 3.89) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.718, 0.102, 205.12],
           "alpha": 1,
           "hex": "#44b6c2"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.20) | 3:1 pair: 800 (contrast: 4.10) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.20) | 3:1 pair: 800 (contrast: 4.10) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.606, 0.115, 205.31],
           "alpha": 1,
@@ -560,8 +560,8 @@
         "description": "3:1 pair: 900 (contrast: 3.40) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.508, 0.107, 206.42],
           "alpha": 1,
@@ -570,8 +570,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.441, 0.093, 207.51],
           "alpha": 1,
@@ -580,8 +580,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.376, 0.079, 208.44],
           "alpha": 1,
@@ -590,8 +590,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.318, 0.062, 209.18],
           "alpha": 1,
@@ -600,8 +600,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.253, 0.041, 210.53],
           "alpha": 1,
@@ -612,68 +612,68 @@
     },
     "blue": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.981, 0.014, 218.951],
           "alpha": 1,
           "hex": "#effbff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.38) | 3:1 pair: 500 (contrast: 3.49) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.38) | 3:1 pair: 500 (contrast: 3.49) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.959, 0.026, 231.237],
           "alpha": 1,
           "hex": "#e1f5ff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.06) | 3:1 pair: 500 (contrast: 3.27) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.06) | 3:1 pair: 500 (contrast: 3.27) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.931, 0.04, 240.111],
           "alpha": 1,
           "hex": "#d1edff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.65) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.8619, 0.0786, 247.216],
           "alpha": 1,
           "hex": "#a8d7ff"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 4.67) | 3:1 pair: 600 (contrast: 3.75) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 4.67) | 3:1 pair: 600 (contrast: 3.75) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.7908, 0.1195, 250.418],
           "alpha": 1,
           "hex": "#7ec0ff"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 4.78) | 3:1 pair: 700 (contrast: 3.68) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 4.78) | 3:1 pair: 700 (contrast: 3.68) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.714, 0.166, 252.066],
           "alpha": 1,
           "hex": "#4aa6ff"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.17) | 3:1 pair: 800 (contrast: 3.61) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.17) | 3:1 pair: 800 (contrast: 3.61) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.622, 0.196, 255.3],
           "alpha": 1,
@@ -682,8 +682,8 @@
         "description": "3:1 pair: 900 (contrast: 3.57) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.518, 0.181, 255.4],
           "alpha": 1,
@@ -692,8 +692,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.466, 0.156, 255.5],
           "alpha": 1,
@@ -702,8 +702,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.404, 0.123, 257.4],
           "alpha": 1,
@@ -712,8 +712,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.315, 0.105, 261.1],
           "alpha": 1,
@@ -722,8 +722,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.245, 0.075, 254.5],
           "alpha": 1,
@@ -734,68 +734,68 @@
     },
     "purple": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.976, 0.018, 315.668],
           "alpha": 1,
           "hex": "#fcf4ff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.32) | 3:1 pair: 500 (contrast: 3.54) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.32) | 3:1 pair: 500 (contrast: 3.54) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.959, 0.032, 316.515],
           "alpha": 1,
           "hex": "#faebff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.04) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.04) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.929, 0.058, 317.538],
           "alpha": 1,
           "hex": "#f8dcff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.57) | 3:1 pair: 500 (contrast: 3.04) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.57) | 3:1 pair: 500 (contrast: 3.04) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.868, 0.1, 312.379],
           "alpha": 1,
           "hex": "#eac1ff"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.06) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.06) | 3:1 pair: 600 (contrast: 3.72) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.808, 0.131, 311.7],
           "alpha": 1,
           "hex": "#dca7fe"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.43) | 3:1 pair: 700 (contrast: 4.09) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.43) | 3:1 pair: 700 (contrast: 4.09) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.724, 0.152, 312.5],
           "alpha": 1,
           "hex": "#c687ea"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.15) | 3:1 pair: 800 (contrast: 3.98) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.15) | 3:1 pair: 800 (contrast: 3.98) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.628, 0.168, 312.7],
           "alpha": 1,
@@ -804,8 +804,8 @@
         "description": "3:1 pair: 900 (contrast: 3.51) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.529, 0.157, 312.4],
           "alpha": 1,
@@ -814,8 +814,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.455, 0.135, 312.5],
           "alpha": 1,
@@ -824,8 +824,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.385, 0.112, 312.4],
           "alpha": 1,
@@ -834,8 +834,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.315, 0.086, 311.1],
           "alpha": 1,
@@ -844,8 +844,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.255, 0.065, 312.5],
           "alpha": 1,
@@ -856,68 +856,68 @@
     },
     "pink": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.974, 0.028, 329.217],
           "alpha": 1,
           "hex": "#fff0ff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.36) | 3:1 pair: 500 (contrast: 3.37) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.36) | 3:1 pair: 500 (contrast: 3.37) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.9577, 0.047, 329.385],
           "alpha": 1,
           "hex": "#ffe6ff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.07) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.07) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.94, 0.067, 329.515],
           "alpha": 1,
           "hex": "#ffdcff"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.78) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.78) | 3:1 pair: 500 (contrast: 3.01) | Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.887, 0.103, 327.5],
           "alpha": 1,
           "hex": "#ffc2fd"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.15) | 3:1 pair: 600 (contrast: 4.00) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.15) | 3:1 pair: 600 (contrast: 4.00) | Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.808, 0.124, 333.7],
           "alpha": 1,
           "hex": "#f1a1e2"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 5.68) | 3:1 pair: 700 (contrast: 3.92) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 5.68) | 3:1 pair: 700 (contrast: 3.92) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.726, 0.145, 338.9],
           "alpha": 1,
           "hex": "#e180c5"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 4.19) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 5.13) | 3:1 pair: 800 (contrast: 4.19) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.637, 0.148, 338.9],
           "alpha": 1,
@@ -926,8 +926,8 @@
         "description": "3:1 pair: 900 (contrast: 3.63) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.525, 0.141, 345.2],
           "alpha": 1,
@@ -936,8 +936,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.464, 0.124, 348.5],
           "alpha": 1,
@@ -946,8 +946,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.373, 0.103, 350],
           "alpha": 1,
@@ -956,8 +956,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.317, 0.082, 350.5],
           "alpha": 1,
@@ -966,8 +966,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.267, 0.052, 350.1],
           "alpha": 1,
@@ -978,38 +978,38 @@
     },
     "slate": {
       "25": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.985, 0.003, 255.5],
           "alpha": 1,
           "hex": "#f9fafc"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.50) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.50) | 3:1 pair: 500 (contrast: 3.35) | Passes on: black"
       },
       "50": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.969, 0.005, 255.5],
           "alpha": 1,
           "hex": "#f3f5f8"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 5.25) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 5.25) | 3:1 pair: 500 (contrast: 3.19) | Passes on: black"
       },
       "100": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.944, 0.008, 255.5],
           "alpha": 1,
           "hex": "#e9edf2"
         },
-        "$description": "4.5:1 pair: 600 (contrast: 4.87) | 3:1 pair: 600 (contrast: 4.87) | Passes on: black"
+        "description": "4.5:1 pair: 600 (contrast: 4.87) | 3:1 pair: 600 (contrast: 4.87) | Passes on: black"
       },
       "150": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.908, 0.012, 255.5],
           "alpha": 1,
@@ -1018,18 +1018,18 @@
         "description": "Passes on: black"
       },
       "200": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.871, 0.015, 255.5],
           "alpha": 1,
           "hex": "#ced5df"
         },
-        "$description": "4.5:1 pair: 700 (contrast: 5.03) | 3:1 pair: 600 (contrast: 3.89) | Passes on: black"
+        "description": "4.5:1 pair: 700 (contrast: 5.03) | 3:1 pair: 600 (contrast: 3.89) | Passes on: black"
       },
       "250": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.835, 0.018, 255.5],
           "alpha": 1,
@@ -1038,28 +1038,28 @@
         "description": "Passes on: black"
       },
       "300": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.803, 0.022, 255.5],
           "alpha": 1,
           "hex": "#b6c0cd"
         },
-        "$description": "4.5:1 pair: 800 (contrast: 6.09) | 3:1 pair: 700 (contrast: 4.02) | Passes on: black"
+        "description": "4.5:1 pair: 800 (contrast: 6.09) | 3:1 pair: 700 (contrast: 4.02) | Passes on: black"
       },
       "400": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.72, 0.025, 255.5],
           "alpha": 1,
           "hex": "#9ba6b4"
         },
-        "$description": "4.5:1 pair: 900 (contrast: 7.15) | 3:1 pair: 800 (contrast: 4.54) | Passes on: black"
+        "description": "4.5:1 pair: 900 (contrast: 7.15) | 3:1 pair: 800 (contrast: 4.54) | Passes on: black"
       },
       "500": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.63, 0.028, 255.5],
           "alpha": 1,
@@ -1068,8 +1068,8 @@
         "description": "3:1 pair: 900 (contrast: 5.07) | Passes on: black"
       },
       "600": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.51, 0.025, 255.5],
           "alpha": 1,
@@ -1078,8 +1078,8 @@
         "description": "Passes on: white"
       },
       "700": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.45, 0.022, 255.5],
           "alpha": 1,
@@ -1088,8 +1088,8 @@
         "description": "Passes on: white"
       },
       "800": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.351, 0.018, 255.5],
           "alpha": 1,
@@ -1098,8 +1098,8 @@
         "description": "Passes on: white"
       },
       "850": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.29, 0.015, 255.5],
           "alpha": 1,
@@ -1108,8 +1108,8 @@
         "description": "Passes on: white"
       },
       "900": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.21, 0.012, 255.5],
           "alpha": 1,
@@ -1118,8 +1118,8 @@
         "description": "Passes on: white"
       },
       "950": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.15, 0.008, 255.5],
           "alpha": 1,
@@ -1128,8 +1128,8 @@
         "description": "Passes on: white"
       },
       "975": {
-        "$type": "color",
-        "$value": {
+        "type": "color",
+        "value": {
           "colorSpace": "oklch",
           "components": [0.11, 0.006, 255.5],
           "alpha": 1,

--- a/tokens/sys/brand/canvas.json
+++ b/tokens/sys/brand/canvas.json
@@ -2,177 +2,182 @@
   "brand": {
     "primary": {
       "lightest": {
-        "value": "{palette.blueberry.100}",
+        "value": "{palette.blue.100}",
         "type": "color"
       },
       "light": {
-        "value": "{palette.blueberry.200}",
+        "value": "{palette.blue.200}",
         "type": "color"
       },
       "base": {
-        "value": "{palette.blueberry.400}",
+        "value": "{palette.blue.600}",
         "type": "color"
       },
       "dark": {
-        "value": "{palette.blueberry.500}",
+        "value": "{palette.blue.700}",
         "type": "color"
       },
       "darkest": {
-        "value": "{palette.blueberry.600}",
+        "value": "{palette.blue.800}",
         "type": "color"
       },
       "accent": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color"
       }
     },
     "alert": {
       "lightest": {
-        "value": "{palette.cantaloupe.100}",
+        "value": "{palette.amber.50}",
         "type": "color"
       },
       "light": {
-        "value": "{palette.cantaloupe.200}",
+        "value": "{palette.amber.100}",
         "type": "color"
       },
       "base": {
-        "value": "{palette.cantaloupe.400}",
+        "value": "{palette.amber.400}",
         "type": "color"
       },
       "dark": {
-        "value": "{palette.cantaloupe.500}",
+        "value": "{palette.amber.600}",
         "type": "color"
       },
       "darkest": {
-        "value": "{palette.cantaloupe.600}",
+        "value": "{palette.amber.800}",
         "type": "color"
       },
       "accent": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.900}",
         "type": "color"
       }
     },
     "error": {
       "lightest": {
-        "value": "{palette.cinnamon.100}",
+        "value": "{palette.red.100}",
         "type": "color"
       },
       "light": {
-        "value": "{palette.cinnamon.200}",
+        "value": "{palette.red.200}",
         "type": "color"
       },
       "base": {
-        "value": "{palette.cinnamon.500}",
+        "value": "{palette.red.700}",
         "type": "color"
       },
       "dark": {
-        "value": "{palette.cinnamon.600}",
+        "value": "{palette.red.600}",
         "type": "color"
       },
       "darkest": {
-        "value": "#80160E",
+        "value": "{palette.red.800}",
         "type": "color"
       },
       "accent": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color"
       }
     },
     "success": {
       "lightest": {
-        "value": "{palette.green-apple.100}",
+        "value": "{palette.green.100}",
         "type": "color"
       },
       "light": {
-        "value": "{palette.green-apple.300}",
+        "value": "{palette.green.200}",
         "type": "color"
       },
       "base": {
-        "value": "{palette.green-apple.400}",
+        "value": "{palette.green.600}",
         "type": "color"
       },
       "dark": {
-        "value": "{palette.green-apple.500}",
+        "value": "{palette.green.700}",
         "type": "color"
       },
       "darkest": {
-        "value": "{palette.green-apple.600}",
+        "value": "{palette.green.800}",
         "type": "color"
       },
       "accent": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color"
       }
     },
     "neutral": {
       "lightest": {
-        "value": "{palette.soap.200}",
+        "value": "{palette.slate.100}",
         "type": "color"
       },
       "light": {
-        "value": "{palette.soap.300}",
+        "value": "{palette.slate.200}",
         "type": "color"
       },
       "base": {
-        "value": "{palette.soap.600}",
+        "value": "{palette.slate.600}",
         "type": "color"
       },
       "dark": {
-        "value": "{palette.licorice.300}",
+        "value": "{palette.slate.700}",
         "type": "color"
       },
       "darkest": {
-        "value": "{palette.licorice.400}",
+        "value": "{palette.slate.800}",
         "type": "color"
       },
       "accent": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color"
       }
     },
     "action": {
       "lightest": {
-        "value": "{brand.primary.lightest}",
+        "value": "{palette.blue.100}",
         "type": "color",
         "description": "Lightest action color"
       },
+      "lighter": {
+        "value": "{palette.blue.200}",
+        "type": "color",
+        "description": "Lighter action color"
+      },
       "light": {
-        "value": "{brand.primary.light}",
+        "value": "{palette.blue.300}",
         "type": "color",
         "description": "Light action color"
       },
       "base": {
-        "value": "{brand.primary.base}",
+        "value": "{palette.blue.600}",
         "type": "color",
         "description": "Base action color"
       },
       "dark": {
-        "value": "{brand.primary.dark}",
+        "value": "{palette.blue.700}",
         "type": "color",
         "description": "Dark action color"
       },
       "darkest": {
-        "value": "{brand.primary.darkest}",
+        "value": "{palette.blue.800}",
         "type": "color",
         "description": "Darkest action color"
       },
       "accent": {
-        "value": "{brand.primary.accent}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Foreground color in actions"
       }
     },
     "common": {
       "focus-outline": {
-        "value": "{palette.blueberry.400}",
+        "value": "{palette.blue.600}",
         "type": "color"
       },
       "error-inner": {
-        "value": "{palette.cinnamon.500}",
+        "value": "{palette.red.700}",
         "type": "color"
       },
       "alert-inner": {
-        "value": "{palette.cantaloupe.400}",
+        "value": "{palette.amber.400}",
         "type": "color"
       }
     },

--- a/tokens/sys/brand/canvas.json
+++ b/tokens/sys/brand/canvas.json
@@ -169,11 +169,11 @@
     },
     "common": {
       "focus-outline": {
-        "value": "{palette.blue.600}",
+        "value": "{palette.blue.500}",
         "type": "color"
       },
       "error-inner": {
-        "value": "{palette.red.700}",
+        "value": "{palette.red.500}",
         "type": "color"
       },
       "alert-inner": {

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -535,7 +535,7 @@
         }
       },
       "transparent": {
-        "value": "oklch({base.1000},{opacity.0})",
+        "value": "oklch({base.1000}/{opacity.0})",
         "type": "color",
         "description": "Transparent"
       },
@@ -562,12 +562,12 @@
     },
     "shadow": {
       "1": {
-        "value": "oklch({slate.850},{opacity.200})",
+        "value": "oklch({slate.850}/{opacity.200})",
         "type": "color",
         "description": "First shadow color"
       },
       "2": {
-        "value": "oklch({slate.850},{opacity.100})",
+        "value": "oklch({slate.850}/{opacity.100})",
         "type": "color",
         "description": "Second shadow color"
       },

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -2,616 +2,681 @@
   "color": {
     "bg": {
       "default": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
-        "description": "Main background color\n"
+        "description": "Main background color"
       },
       "transparent": {
-        "value": "rgba({palette.french-vanilla.100},0)",
+        "value": "#ffffff00",
         "type": "color",
         "description": "Transparent background"
       },
       "overlay": {
-        "value": "rgba({color.static.black},{opacity.400})",
+        "value": "#000000a3",
         "type": "color",
         "description": "Overlay background"
       },
       "translucent": {
-        "value": "rgba({palette.black-pepper.600},{opacity.500})",
+        "value": "#000000d6",
         "type": "color",
         "description": "Tooltip, Status Indicator"
       },
       "alt": {
         "default": {
-          "value": "{palette.soap.300}",
+          "value": "{palette.slate.100}",
           "type": "color",
           "description": "Hover states"
         },
         "soft": {
-          "value": "{palette.soap.200}",
+          "value": "{palette.slate.50}",
           "type": "color",
           "description": "Page background"
         },
-        "softer": {
-          "value": "{palette.soap.100}",
-          "type": "color",
-          "description": "Disabled inputs and column headers"
-        },
         "strong": {
-          "value": "{palette.soap.400}",
+          "value": "{palette.slate.150}",
           "type": "color",
           "description": "Active states"
         },
         "stronger": {
-          "value": "{palette.soap.500}",
+          "value": "{palette.slate.200}",
           "type": "color",
           "description": "Active states"
+        },
+        "softer": {
+          "value": "{palette.slate.25}",
+          "type": "color",
+          "description": "Disabled inputs and column headers"
         }
       },
       "muted": {
-        "softer": {
-          "value": "{palette.licorice.100}",
-          "type": "color"
-        },
         "soft": {
-          "value": "{palette.licorice.200}",
+          "value": "{palette.slate.300}",
           "type": "color"
         },
         "default": {
-          "value": "{palette.licorice.300}",
+          "value": "{palette.slate.400}",
           "type": "color"
         },
         "strong": {
-          "value": "{palette.licorice.500}",
+          "value": "{palette.slate.600}",
+          "type": "color"
+        },
+        "softer": {
+          "value": "{palette.slate.250}",
           "type": "color"
         }
       },
       "contrast": {
         "default": {
-          "value": "{palette.black-pepper.400}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons"
         },
         "strong": {
-          "value": "{palette.black-pepper.500}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons"
         }
       },
       "primary": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.600}",
           "type": "color",
           "description": "Primary brand color"
         },
         "soft": {
-          "value": "{palette.blueberry.200}",
+          "value": "{palette.blue.100}",
           "type": "color",
           "description": "Brand selected background"
         },
         "strong": {
-          "value": "{palette.blueberry.500}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Brand hover background"
         },
         "stronger": {
-          "value": "{palette.blueberry.600}",
+          "value": "{palette.blue.900}",
           "type": "color",
           "description": "Brand active background"
+        },
+        "softer": {
+          "value": "{palette.blue.50}",
+          "type": "color",
+          "description": "Brand selected background"
         }
       },
       "positive": {
         "default": {
-          "value": "{palette.green-apple.400}",
+          "value": "{palette.green.600}",
           "type": "color",
           "description": "Disabled success background"
         },
-        "softer": {
-          "value": "{palette.green-apple.100}",
-          "type": "color",
-          "description": "Softer success background"
-        },
         "strong": {
-          "value": "{palette.green-apple.500}",
+          "value": "{palette.green.800}",
           "type": "color",
           "description": "Hover success background"
         },
         "stronger": {
-          "value": "{palette.green-apple.600}",
+          "value": "{palette.green.900}",
           "type": "color",
           "description": "Active success background"
+        },
+        "softer": {
+          "value": "{palette.green.50}",
+          "type": "color",
+          "description": "Softer success background"
+        },
+        "soft": {
+          "value": "{palette.green.100}",
+          "type": "color",
+          "description": "Soft success background"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.cantaloupe.400}",
+          "value": "{palette.amber.400}",
           "type": "color",
           "description": "Default warning background"
         },
         "softer": {
-          "value": "{palette.cantaloupe.100}",
+          "value": "{palette.amber.50}",
           "type": "color",
           "description": "Disabled warning background"
         },
         "strong": {
-          "value": "{palette.cantaloupe.500}",
+          "value": "{palette.amber.500}",
           "type": "color",
           "description": "Strong warning background"
         },
         "stronger": {
-          "value": "{palette.cantaloupe.600}",
+          "value": "{palette.amber.600}",
           "type": "color",
           "description": "Stronger warning background"
+        },
+        "soft": {
+          "value": "{palette.amber.100}",
+          "type": "color",
+          "description": "Softer warning background"
         }
       },
       "critical": {
         "default": {
-          "value": "{palette.cinnamon.500}",
+          "value": "{palette.red.600}",
           "type": "color",
           "description": "Default error background"
         },
         "softer": {
-          "value": "{palette.cinnamon.100}",
+          "value": "{palette.red.50}",
           "type": "color",
           "description": "Disabled error background"
         },
         "strong": {
-          "value": "{palette.cinnamon.600}",
+          "value": "{palette.red.700}",
           "type": "color",
           "description": "Strong error background"
         },
         "stronger": {
-          "value": "#80160E",
+          "value": "{palette.red.800}",
           "type": "color",
           "description": "Stronger error background"
+        },
+        "soft": {
+          "value": "{palette.red.100}",
+          "type": "color",
+          "description": "Disabled error background"
+        }
+      },
+      "ai": {
+        "default": {
+          "value": "{palette.blue.100}",
+          "type": "color",
+          "description": "AI container"
+        },
+        "strong": {
+          "value": "{palette.blue.200}",
+          "type": "color",
+          "description": "Hover on AI container"
+        },
+        "stronger": {
+          "value": "{palette.blue.400}",
+          "type": "color",
+          "description": "Active state on AI containers"
+        },
+        "strongest": {
+          "value": "{palette.blue.950}",
+          "type": "color",
+          "description": "AI surfaces"
         }
       }
     },
     "text": {
       "default": {
-        "value": "{palette.black-pepper.300}",
+        "value": "{palette.base.800}",
         "type": "color",
         "description": "Default text color"
       },
       "disabled": {
-        "value": "{palette.licorice.100}",
+        "value": "{palette.slate.400}",
         "type": "color",
         "description": "Disabled text color"
       },
       "hint": {
-        "value": "{palette.licorice.300}",
+        "value": "{palette.slate.600}",
         "type": "color",
         "description": "Hint text color"
       },
       "strong": {
-        "value": "{palette.black-pepper.400}",
+        "value": "{palette.base.900}",
         "type": "color",
         "description": "Heading text color"
       },
       "stronger": {
-        "value": "{palette.black-pepper.500}",
+        "value": "{palette.base.950}",
         "type": "color",
         "description": "Heading hover text color"
       },
       "inverse": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Inverse text color"
       },
       "critical": {
         "default": {
-          "value": "{palette.cinnamon.500}",
+          "value": "{palette.red.600}",
           "type": "color",
           "description": "Error text"
         }
       },
       "primary": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.600}",
           "type": "color",
           "description": "Branded text"
         },
         "strong": {
-          "value": "{palette.blueberry.500}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Branded hover text"
         },
         "stronger": {
-          "value": "{palette.blueberry.600}",
+          "value": "{palette.blue.900}",
           "type": "color",
           "description": "Active links"
         }
       },
       "caution": {
         "default": {
-          "value": "{color.text.strong}",
+          "value": "{palette.base.850}",
           "type": "color",
           "description": "Warning text"
         },
         "strong": {
-          "value": "{color.text.stronger}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Strong warning text"
         }
+      },
+      "ai": {
+        "value": "{palette.blue.950}",
+        "type": "color"
       }
     },
     "icon": {
       "default": {
-        "value": "{palette.licorice.200}",
+        "value": "{palette.base.800}",
         "type": "color",
         "description": "Default icon color"
       },
       "soft": {
-        "value": "{palette.licorice.100}",
+        "value": "{palette.slate.600}",
         "type": "color",
         "description": "Disabled icon color"
       },
       "strong": {
-        "value": "{palette.licorice.500}",
+        "value": "{palette.base.900}",
         "type": "color",
         "description": "Hover icon color"
       },
       "inverse": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Inverse icon color"
       },
       "primary": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.600}",
           "type": "color",
           "description": "Brand icon color"
         },
         "strong": {
-          "value": "{palette.blueberry.500}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Stronger brand icon color"
         }
       },
       "positive": {
         "default": {
-          "value": "{palette.green-apple.500}",
+          "value": "{palette.green.600}",
           "type": "color",
           "description": "Success icon color"
         }
       },
       "critical": {
         "default": {
-          "value": "{palette.cinnamon.500}",
+          "value": "{palette.red.600}",
           "type": "color",
           "description": "Error icon color"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.black-pepper.400}",
+          "value": "{palette.base.850}",
           "type": "color",
           "description": "Caution icon color"
         },
         "strong": {
-          "value": "{palette.black-pepper.500}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Strong caution icon color"
         }
+      },
+      "disabled": {
+        "value": "{palette.slate.400}",
+        "type": "color",
+        "description": "Disabled icon color"
       }
     },
     "fg": {
       "default": {
-        "value": "{palette.black-pepper.300}",
+        "value": "{palette.base.850}",
         "type": "color",
         "description": "Body"
       },
       "strong": {
-        "value": "{palette.black-pepper.400}",
+        "value": "{palette.base.900}",
         "type": "color",
         "description": "Headings"
       },
       "stronger": {
-        "value": "{palette.black-pepper.500}",
+        "value": "{palette.base.950}",
         "type": "color",
         "description": "Heading on hover"
       },
       "disabled": {
-        "value": "{palette.licorice.100}",
+        "value": "{palette.slate.400}",
         "type": "color",
         "description": "Disabled"
       },
       "inverse": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Inverse"
       },
       "critical": {
-        "default": {
-          "value": "{palette.cinnamon.500}",
-          "type": "color",
-          "description": "Error"
-        }
+        "value": "{palette.red.600}",
+        "type": "color",
+        "description": "Error"
       },
       "muted": {
-        "soft": {
-          "value": "{palette.licorice.200}",
-          "type": "color",
-          "description": "Tab item text"
-        },
         "default": {
-          "value": "{palette.licorice.300}",
+          "value": "{palette.slate.600}",
           "type": "color",
           "description": "Hint text"
         },
         "strong": {
-          "value": "{palette.licorice.400}",
+          "value": "{palette.slate.700}",
           "type": "color"
         },
         "stronger": {
-          "value": "{palette.licorice.500}",
+          "value": "{palette.slate.800}",
           "type": "color"
+        },
+        "soft": {
+          "value": "{palette.slate.400}",
+          "type": "color",
+          "description": "Tab item foreground"
         }
       },
       "primary": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.600}",
           "type": "color",
-          "description": "Interactive foreground elements"
+          "description": "Links"
         },
         "strong": {
-          "value": "{palette.blueberry.500}",
+          "value": "{palette.blue.800}",
           "type": "color",
-          "description": "Hover interactive foregrounds"
+          "description": "Links on hover"
+        },
+        "soft": {
+          "value": "{palette.blue.300}",
+          "type": "color",
+          "description": "Link Inverse"
+        },
+        "softer": {
+          "value": "{palette.blue.200}",
+          "type": "color",
+          "description": "Link Inverse"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.black-pepper.400}",
+          "value": "{palette.base.850}",
           "type": "color",
           "description": "Warning"
         },
         "strong": {
-          "value": "{palette.black-pepper.500}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Warning on hover"
         }
       },
       "contrast": {
         "default": {
-          "value": "{palette.black-pepper.400}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Contrast"
         },
         "strong": {
-          "value": "{palette.black-pepper.500}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Strong contrast"
         }
+      },
+      "ai": {
+        "value": "{palette.blue.950}",
+        "type": "color",
+        "description": "AI icons and text"
       }
     },
     "border": {
       "input": {
         "disabled": {
-          "value": "{palette.licorice.100}",
+          "value": "{palette.slate.400}",
           "type": "color",
           "description": "Disabled inputs"
         },
         "default": {
-          "value": "{palette.licorice.200}",
+          "value": "{palette.slate.500}",
           "type": "color",
           "description": "Inputs"
         },
         "strong": {
-          "value": "{palette.licorice.500}",
+          "value": "{palette.slate.700}",
           "type": "color",
           "description": "Input hover"
         },
         "inverse": {
-          "value": "{palette.soap.300}",
+          "value": "{palette.base.0}",
           "type": "color",
           "description": "Borders on checkboxes and radios"
         }
       },
       "contrast": {
         "default": {
-          "value": "{palette.black-pepper.400}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Secondary Button"
         },
         "strong": {
-          "value": "{palette.black-pepper.500}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Secondary Button Hover"
         }
       },
       "primary": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.500}",
           "type": "color",
           "description": "Brand, Focus"
         }
       },
       "critical": {
         "default": {
-          "value": "{palette.cinnamon.500}",
+          "value": "{palette.red.500}",
           "type": "color",
           "description": "Error"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.cantaloupe.400}",
+          "value": "{palette.amber.400}",
           "type": "color",
           "description": "Warning inner"
         },
         "strong": {
-          "value": "{palette.cantaloupe.600}",
+          "value": "{palette.amber.500}",
           "type": "color",
           "description": "Warning outer (box shadow)"
         }
       },
       "transparent": {
-        "value": "rgba({color.static.white},0%)",
+        "value": "#ffffff00",
         "type": "color",
         "description": "Transparent"
       },
       "inverse": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Inverse"
       },
       "divider": {
-        "value": "{palette.soap.400}",
+        "value": "{palette.slate.200}",
         "type": "color",
         "description": "Dividers"
       },
       "container": {
-        "value": "{palette.soap.500}",
+        "value": "{palette.slate.300}",
         "type": "color",
         "description": "Cards, Toasts"
+      },
+      "ai": {
+        "value": "{palette.blue.950}",
+        "type": "color"
       }
     },
     "shadow": {
       "1": {
-        "value": "{color.shadow.default}",
+        "value": "#15191e1f",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": "{opacity.200}",
-              "space": "lch"
-            }
-          }
-        },
         "description": "First shadow color"
       },
       "2": {
-        "value": "{palette.licorice.600}",
+        "value": "#15191e14",
         "type": "color",
-        "$extensions": {
-          "studio.tokens": {
-            "modify": {
-              "type": "alpha",
-              "value": "{opacity.100}",
-              "space": "lch"
-            }
-          }
-        },
         "description": "Second shadow color"
       },
       "default": {
-        "value": "{palette.licorice.600}",
+        "value": "{palette.slate.900}",
         "type": "color",
-        "description": "Main shadow color",
-        "$extensions": {
-          "studio.tokens": {}
-        }
+        "description": "Main shadow color"
       }
     },
     "static": {
       "blue": {
         "default": {
-          "value": "{palette.blueberry.400}",
+          "value": "{palette.blue.600}",
           "type": "color",
           "description": "Blue"
         },
         "soft": {
-          "value": "{palette.blueberry.100}",
+          "value": "{palette.blue.100}",
           "type": "color",
           "description": "Light blue"
         },
         "strong": {
-          "value": "{palette.blueberry.500}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Stronger blue"
         }
       },
-      "gold": {
-        "stronger": {
-          "value": "{palette.toasted-marshmallow.600}",
-          "type": "color",
-          "description": "Foregrounds in low emphasis status indicators"
-        }
-      },
       "green": {
         "default": {
-          "value": "{palette.green-apple.400}",
+          "value": "{palette.green.600}",
           "type": "color",
           "description": "Default green"
         },
         "soft": {
-          "value": "{palette.green-apple.100}",
+          "value": "{palette.green.100}",
           "type": "color",
           "description": "Light green"
         },
         "strong": {
-          "value": "{palette.green-apple.600}",
+          "value": "{palette.green.800}",
           "type": "color",
           "description": "Stronger green"
         }
       },
       "red": {
         "default": {
-          "value": "{palette.cinnamon.500}",
+          "value": "{palette.red.600}",
           "type": "color",
           "description": "Red"
         },
         "soft": {
-          "value": "{palette.cinnamon.100}",
+          "value": "{palette.red.100}",
           "type": "color",
           "description": "Light red"
         },
         "strong": {
-          "value": "{palette.cinnamon.600}",
+          "value": "{palette.red.800}",
+          "type": "color",
+          "description": "Strong red"
+        },
+        "stronger": {
+          "value": "{palette.red.900}",
+          "type": "color",
+          "description": "Strong red"
+        },
+        "softer": {
+          "value": "{palette.red.50}",
+          "type": "color",
+          "description": "Light red"
+        },
+        "strongest": {
+          "value": "{palette.red.950}",
           "type": "color",
           "description": "Strong red"
         }
       },
-      "orange": {
-        "default": {
-          "value": "{palette.cantaloupe.400}",
-          "type": "color",
-          "description": "Orange"
-        },
-        "soft": {
-          "value": "{palette.cantaloupe.100}",
-          "type": "color",
-          "description": "Soft orange"
-        },
-        "strong": {
-          "value": "{palette.cantaloupe.600}",
-          "type": "color",
-          "description": "Stronger orange"
-        }
-      },
-      "gray": {
-        "default": {
-          "value": "{palette.licorice.300}",
-          "type": "color",
-          "description": "Gray"
-        },
-        "soft": {
-          "value": "{palette.soap.300}",
-          "type": "color",
-          "description": "Light gray"
-        },
-        "strong": {
-          "value": "{palette.licorice.400}",
-          "type": "color",
-          "description": "Stronger gray"
-        },
-        "stronger": {
-          "value": "{palette.licorice.500}",
-          "type": "color",
-          "description": "Strongerer gray"
-        }
-      },
       "white": {
-        "value": "{palette.french-vanilla.100}",
+        "value": "{palette.base.0}",
         "type": "color",
         "description": "Just white"
       },
       "black": {
-        "value": "{palette.black-pepper.600}",
+        "value": "{palette.base.1000}",
         "type": "color",
         "description": "Just black"
+      },
+      "gray": {
+        "default": {
+          "value": "{palette.slate.600}",
+          "type": "color",
+          "description": "Gray"
+        },
+        "soft": {
+          "value": "{palette.slate.100}",
+          "type": "color",
+          "description": "Light gray"
+        },
+        "strong": {
+          "value": "{palette.slate.800}",
+          "type": "color",
+          "description": "Stronger gray"
+        },
+        "stronger": {
+          "value": "{palette.slate.850}",
+          "type": "color",
+          "description": "Strongerer gray"
+        },
+        "strongest": {
+          "value": "{palette.slate.900}",
+          "type": "color",
+          "description": "Strongerer gray"
+        }
+      },
+      "amber": {
+        "default": {
+          "value": "{palette.amber.400}",
+          "type": "color",
+          "description": "amber"
+        },
+        "soft": {
+          "value": "{palette.amber.50}",
+          "type": "color",
+          "description": "Soft amber"
+        },
+        "strong": {
+          "value": "{palette.amber.500}",
+          "type": "color",
+          "description": "Stronger amber"
+        },
+        "stronger": {
+          "value": "{palette.amber.600}",
+          "type": "color",
+          "description": "Stronger amber"
+        }
       }
     }
   }

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -7,17 +7,17 @@
         "description": "Main background color"
       },
       "transparent": {
-        "value": "rgba({base.0},0)",
+        "value": "oklch({base.0}/{opacity.0})",
         "type": "color",
         "description": "Transparent background"
       },
       "overlay": {
-        "value": "rgba({base.1000,{opacity.400})",
+        "value": "oklch({base.1000}/{opacity.400})",
         "type": "color",
         "description": "Overlay background"
       },
       "translucent": {
-        "value": "rgba({base.1000,{opacity.500})",
+        "value": "oklch({base.1000}/{opacity.500})",
         "type": "color",
         "description": "Tooltip, Status Indicator"
       },
@@ -535,7 +535,7 @@
         }
       },
       "transparent": {
-        "value": "rgba({base.1000},{opacity.0})",
+        "value": "oklch({base.1000},{opacity.0})",
         "type": "color",
         "description": "Transparent"
       },
@@ -562,12 +562,12 @@
     },
     "shadow": {
       "1": {
-        "value": "rgba({slate.850},{opacity.200})",
+        "value": "oklch({slate.850},{opacity.200})",
         "type": "color",
         "description": "First shadow color"
       },
       "2": {
-        "value": "rgba({slate.850},{opacity.100})",
+        "value": "oklch({slate.850},{opacity.100})",
         "type": "color",
         "description": "Second shadow color"
       },

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -7,48 +7,52 @@
         "description": "Main background color"
       },
       "transparent": {
-        "value": "#ffffff00",
+        "value": "rgba({base.0},0)",
         "type": "color",
         "description": "Transparent background"
       },
       "overlay": {
-        "value": "#000000a3",
+        "value": "rgba({base.1000,{opacity.400})",
         "type": "color",
         "description": "Overlay background"
       },
       "translucent": {
-        "value": "#000000d6",
+        "value": "rgba({base.1000,{opacity.500})",
         "type": "color",
         "description": "Tooltip, Status Indicator"
       },
       "alt": {
-        "default": {
-          "value": "{palette.slate.100}",
+        "softer": {
+          "value": "{palette.slate.25}",
           "type": "color",
-          "description": "Hover states"
+          "description": "Disabled inputs"
         },
         "soft": {
           "value": "{palette.slate.50}",
           "type": "color",
-          "description": "Page background"
+          "description": "Alternative page background"
+        },
+        "default": {
+          "value": "{palette.slate.100}",
+          "type": "color",
+          "description": "Surface hover, Secondary surfaces"
         },
         "strong": {
           "value": "{palette.slate.150}",
           "type": "color",
-          "description": "Active states"
+          "description": "Dividers"
         },
         "stronger": {
           "value": "{palette.slate.200}",
           "type": "color",
-          "description": "Active states"
-        },
-        "softer": {
-          "value": "{palette.slate.25}",
-          "type": "color",
-          "description": "Disabled inputs and column headers"
+          "description": "Active state for segmented control, Pill"
         }
       },
       "muted": {
+        "softer": {
+          "value": "{palette.slate.250}",
+          "type": "color"
+        },
         "soft": {
           "value": "{palette.slate.300}",
           "type": "color"
@@ -58,22 +62,18 @@
           "type": "color"
         },
         "strong": {
-          "value": "{palette.slate.600}",
-          "type": "color"
-        },
-        "softer": {
-          "value": "{palette.slate.250}",
+          "value": "{palette.slate.500}",
           "type": "color"
         }
       },
       "contrast": {
         "default": {
-          "value": "{palette.base.900}",
+          "value": "{palette.base.850}",
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons"
         },
         "strong": {
-          "value": "{palette.base.950}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons"
         }
@@ -84,25 +84,30 @@
           "type": "color",
           "description": "Primary brand color"
         },
-        "soft": {
+        "softer": {
           "value": "{palette.blue.100}",
           "type": "color",
-          "description": "Brand selected background"
+          "description": "Select"
         },
         "strong": {
-          "value": "{palette.blue.800}",
+          "value": "{palette.blue.700}",
           "type": "color",
           "description": "Brand hover background"
         },
         "stronger": {
-          "value": "{palette.blue.900}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Brand active background"
         },
-        "softer": {
-          "value": "{palette.blue.50}",
+        "softest": {
+          "value": "{palette.blue.25}",
           "type": "color",
-          "description": "Brand selected background"
+          "description": "Surface"
+        },
+        "soft": {
+          "value": "{palette.blue.200}",
+          "type": "color",
+          "description": "Disabled"
         }
       },
       "positive": {
@@ -112,24 +117,29 @@
           "description": "Disabled success background"
         },
         "strong": {
-          "value": "{palette.green.800}",
+          "value": "{palette.green.700}",
           "type": "color",
           "description": "Hover success background"
         },
         "stronger": {
-          "value": "{palette.green.900}",
+          "value": "{palette.green.800}",
           "type": "color",
           "description": "Active success background"
         },
-        "softer": {
-          "value": "{palette.green.50}",
+        "softest": {
+          "value": "{palette.green.25}",
           "type": "color",
-          "description": "Softer success background"
+          "description": "Lightest surface success background"
         },
         "soft": {
+          "value": "{palette.green.200}",
+          "type": "color",
+          "description": "Disabled success background"
+        },
+        "softer": {
           "value": "{palette.green.100}",
           "type": "color",
-          "description": "Soft success background"
+          "description": "Surface success background"
         }
       },
       "caution": {
@@ -138,8 +148,8 @@
           "type": "color",
           "description": "Default warning background"
         },
-        "softer": {
-          "value": "{palette.amber.50}",
+        "softest": {
+          "value": "{palette.amber.25}",
           "type": "color",
           "description": "Disabled warning background"
         },
@@ -153,6 +163,11 @@
           "type": "color",
           "description": "Stronger warning background"
         },
+        "softer": {
+          "value": "{palette.amber.50}",
+          "type": "color",
+          "description": "Softer warning background"
+        },
         "soft": {
           "value": "{palette.amber.100}",
           "type": "color",
@@ -165,8 +180,8 @@
           "type": "color",
           "description": "Default error background"
         },
-        "softer": {
-          "value": "{palette.red.50}",
+        "softest": {
+          "value": "{palette.red.25}",
           "type": "color",
           "description": "Disabled error background"
         },
@@ -180,8 +195,13 @@
           "type": "color",
           "description": "Stronger error background"
         },
-        "soft": {
+        "softer": {
           "value": "{palette.red.100}",
+          "type": "color",
+          "description": "Disabled error background"
+        },
+        "soft": {
+          "value": "{palette.red.200}",
           "type": "color",
           "description": "Disabled error background"
         }
@@ -211,7 +231,7 @@
     },
     "text": {
       "default": {
-        "value": "{palette.base.800}",
+        "value": "{palette.base.850}",
         "type": "color",
         "description": "Default text color"
       },
@@ -228,12 +248,12 @@
       "strong": {
         "value": "{palette.base.900}",
         "type": "color",
-        "description": "Heading text color"
+        "description": "Heading color"
       },
       "stronger": {
         "value": "{palette.base.950}",
         "type": "color",
-        "description": "Heading hover text color"
+        "description": "Stronger heading color"
       },
       "inverse": {
         "value": "{palette.base.0}",
@@ -251,27 +271,27 @@
         "default": {
           "value": "{palette.blue.600}",
           "type": "color",
-          "description": "Branded text"
+          "description": "Links"
         },
         "strong": {
-          "value": "{palette.blue.800}",
+          "value": "{palette.blue.700}",
           "type": "color",
-          "description": "Branded hover text"
+          "description": "Links on hover"
         },
         "stronger": {
-          "value": "{palette.blue.900}",
+          "value": "{palette.blue.800}",
           "type": "color",
           "description": "Active links"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.base.850}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Warning text"
         },
         "strong": {
-          "value": "{palette.base.900}",
+          "value": "{palette.base.950}",
           "type": "color",
           "description": "Strong warning text"
         }
@@ -283,7 +303,7 @@
     },
     "icon": {
       "default": {
-        "value": "{palette.base.800}",
+        "value": "{palette.base.850}",
         "type": "color",
         "description": "Default icon color"
       },
@@ -309,6 +329,11 @@
           "description": "Brand icon color"
         },
         "strong": {
+          "value": "{palette.blue.700}",
+          "type": "color",
+          "description": "Stronger brand icon color"
+        },
+        "stronger": {
           "value": "{palette.blue.800}",
           "type": "color",
           "description": "Stronger brand icon color"
@@ -330,7 +355,7 @@
       },
       "caution": {
         "default": {
-          "value": "{palette.base.850}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Caution icon color"
         },
@@ -378,6 +403,11 @@
         "description": "Error"
       },
       "muted": {
+        "soft": {
+          "value": "{palette.slate.400}",
+          "type": "color",
+          "description": "Tab item foreground"
+        },
         "default": {
           "value": "{palette.slate.600}",
           "type": "color",
@@ -390,38 +420,32 @@
         "stronger": {
           "value": "{palette.slate.800}",
           "type": "color"
-        },
-        "soft": {
-          "value": "{palette.slate.400}",
-          "type": "color",
-          "description": "Tab item foreground"
         }
       },
       "primary": {
         "default": {
           "value": "{palette.blue.600}",
           "type": "color",
-          "description": "Links"
+          "description": "Links, Accent"
         },
         "strong": {
-          "value": "{palette.blue.800}",
+          "value": "{palette.blue.700}",
           "type": "color",
           "description": "Links on hover"
         },
         "soft": {
           "value": "{palette.blue.300}",
-          "type": "color",
-          "description": "Link Inverse"
+          "type": "color"
         },
         "softer": {
           "value": "{palette.blue.200}",
           "type": "color",
-          "description": "Link Inverse"
+          "description": "Link Inverse, Disabled"
         }
       },
       "caution": {
         "default": {
-          "value": "{palette.base.850}",
+          "value": "{palette.base.900}",
           "type": "color",
           "description": "Warning"
         },
@@ -511,43 +535,44 @@
         }
       },
       "transparent": {
-        "value": "#ffffff00",
+        "value": "rgba({base.1000},{opacity.0})",
         "type": "color",
         "description": "Transparent"
       },
       "inverse": {
         "value": "{palette.base.0}",
         "type": "color",
-        "description": "Inverse"
+        "description": "Borders on accent colors"
       },
       "divider": {
-        "value": "{palette.slate.200}",
+        "value": "{palette.slate.150}",
         "type": "color",
         "description": "Dividers"
       },
       "container": {
-        "value": "{palette.slate.300}",
+        "value": "{palette.slate.250}",
         "type": "color",
-        "description": "Cards, Toasts"
+        "description": "Cards, Tables, Surfaces"
       },
       "ai": {
         "value": "{palette.blue.950}",
-        "type": "color"
+        "type": "color",
+        "description": "Active state on AI"
       }
     },
     "shadow": {
       "1": {
-        "value": "#15191e1f",
+        "value": "rgba({slate.850},{opacity.200})",
         "type": "color",
         "description": "First shadow color"
       },
       "2": {
-        "value": "#15191e14",
+        "value": "rgba({slate.850},{opacity.100})",
         "type": "color",
         "description": "Second shadow color"
       },
       "default": {
-        "value": "{palette.slate.900}",
+        "value": "{palette.slate.850}",
         "type": "color",
         "description": "Main shadow color"
       }
@@ -565,9 +590,19 @@
           "description": "Light blue"
         },
         "strong": {
+          "value": "{palette.blue.700}",
+          "type": "color",
+          "description": "Stronger blue"
+        },
+        "stronger": {
           "value": "{palette.blue.800}",
           "type": "color",
           "description": "Stronger blue"
+        },
+        "softer": {
+          "value": "{palette.blue.300}",
+          "type": "color",
+          "description": "Light blue"
         }
       },
       "green": {
@@ -577,11 +612,21 @@
           "description": "Default green"
         },
         "soft": {
-          "value": "{palette.green.100}",
+          "value": "{palette.green.300}",
           "type": "color",
           "description": "Light green"
         },
         "strong": {
+          "value": "{palette.green.700}",
+          "type": "color",
+          "description": "Stronger green"
+        },
+        "softer": {
+          "value": "{palette.green.100}",
+          "type": "color",
+          "description": "Light green"
+        },
+        "stronger": {
           "value": "{palette.green.800}",
           "type": "color",
           "description": "Stronger green"
@@ -594,22 +639,22 @@
           "description": "Red"
         },
         "soft": {
-          "value": "{palette.red.100}",
+          "value": "{palette.red.300}",
           "type": "color",
           "description": "Light red"
         },
         "strong": {
-          "value": "{palette.red.800}",
+          "value": "{palette.red.700}",
           "type": "color",
           "description": "Strong red"
         },
         "stronger": {
-          "value": "{palette.red.900}",
+          "value": "{palette.red.800}",
           "type": "color",
           "description": "Strong red"
         },
         "softer": {
-          "value": "{palette.red.50}",
+          "value": "{palette.red.100}",
           "type": "color",
           "description": "Light red"
         },
@@ -636,17 +681,17 @@
           "description": "Gray"
         },
         "soft": {
-          "value": "{palette.slate.100}",
+          "value": "{palette.slate.300}",
           "type": "color",
           "description": "Light gray"
         },
         "strong": {
-          "value": "{palette.slate.800}",
+          "value": "{palette.slate.700}",
           "type": "color",
           "description": "Stronger gray"
         },
         "stronger": {
-          "value": "{palette.slate.850}",
+          "value": "{palette.slate.800}",
           "type": "color",
           "description": "Strongerer gray"
         },
@@ -654,6 +699,11 @@
           "value": "{palette.slate.900}",
           "type": "color",
           "description": "Strongerer gray"
+        },
+        "softer": {
+          "value": "{palette.slate.100}",
+          "type": "color",
+          "description": "Light gray"
         }
       },
       "amber": {
@@ -662,7 +712,7 @@
           "type": "color",
           "description": "amber"
         },
-        "soft": {
+        "softer": {
           "value": "{palette.amber.50}",
           "type": "color",
           "description": "Soft amber"
@@ -676,8 +726,333 @@
           "value": "{palette.amber.600}",
           "type": "color",
           "description": "Stronger amber"
+        },
+        "soft": {
+          "value": "{palette.amber.200}",
+          "type": "color",
+          "description": "Soft amber"
+        },
+        "strongest": {
+          "value": "{palette.amber.700}",
+          "type": "color",
+          "description": "Stronger amber"
         }
       }
+    }
+  },
+  "font-family": {
+    "default": {
+      "value": "{font-family.50}",
+      "type": "text"
+    },
+    "mono": {
+      "value": "{font-family.100}",
+      "type": "text"
+    },
+    "global": {
+      "value": "{font-family.200}",
+      "type": "text"
+    }
+  },
+  "font-weight": {
+    "light": {
+      "value": "{font-weight.300}",
+      "type": "text"
+    },
+    "normal": {
+      "value": "{font-weight.400}",
+      "type": "text"
+    },
+    "medium": {
+      "value": "{font-weight.500}",
+      "type": "text"
+    },
+    "bold": {
+      "value": "{font-weight.700}",
+      "type": "text"
+    }
+  },
+  "space": {
+    "zero": {
+      "value": 0,
+      "type": "number",
+      "description": "Stacks, rows in tables"
+    },
+    "x1": {
+      "value": "{base.unit}",
+      "type": "number",
+      "description": "Compact spacing between text or icons"
+    },
+    "half": {
+      "value": 2,
+      "type": "number",
+      "description": "Mobile only"
+    },
+    "x2": {
+      "value": 8,
+      "type": "number",
+      "description": "Commonly used to group compact elements like icon buttons"
+    },
+    "x3": {
+      "value": 12,
+      "type": "number",
+      "description": "Use when compact padding is required"
+    },
+    "x4": {
+      "value": 16,
+      "type": "number",
+      "description": "Default space token. Used to group Inputs with related data"
+    },
+    "x5": {
+      "value": 20,
+      "type": "number",
+      "description": "Mobile only"
+    },
+    "x6": {
+      "value": 24,
+      "type": "number",
+      "description": "• Padding around card content\n• Related elements where more space between them can be afforded\n• Separate section headings or titles from body text or inputs"
+    },
+    "x8": {
+      "value": 32,
+      "type": "number",
+      "description": "• Standard spacing between cards\n• Used to separate groups of content \n• Separate section headings or titles from body text or inputs"
+    },
+    "x10": {
+      "value": 40,
+      "type": "number",
+      "description": "• Used for outer margins on the overall page content \n• Used for inner margins on large items such as page sections"
+    },
+    "x14": {
+      "value": 56,
+      "type": "number",
+      "description": "Mobile only"
+    },
+    "x16": {
+      "value": 64,
+      "type": "number",
+      "description": "- Use to de-clutter your UI when a lot of space is available\n- Separate banner sections from page content\n- Use to differentiate page content like page sections"
+    },
+    "x20": {
+      "value": 80,
+      "type": "number",
+      "description": "- Use sparingly\n- Helps to put focus on the primary element within your page\n- Use to de-clutter your UI when a lot of space is available"
+    }
+  },
+  "font-size": {
+    "subtext": {
+      "small": {
+        "value": "{font-size.25}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{font-size.50}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{font-size.75}",
+        "type": "number"
+      }
+    },
+    "body": {
+      "small": {
+        "value": "{font-size.100}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{font-size.125}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{font-size.150}",
+        "type": "number"
+      }
+    },
+    "heading": {
+      "small": {
+        "value": "{font-size.200}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{font-size.250}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{font-size.300}",
+        "type": "number"
+      }
+    },
+    "title": {
+      "small": {
+        "value": "{font-size.400}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{font-size.500}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{font-size.600}",
+        "type": "number"
+      }
+    }
+  },
+  "line-height": {
+    "subtext": {
+      "small": {
+        "value": "{line-height.50}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{line-height.50}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{line-height.100}",
+        "type": "number"
+      }
+    },
+    "body": {
+      "small": {
+        "value": "{line-height.150}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{line-height.200}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{line-height.200}",
+        "type": "number"
+      }
+    },
+    "heading": {
+      "small": {
+        "value": "{line-height.250}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{line-height.300}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{line-height.350}",
+        "type": "number"
+      }
+    },
+    "title": {
+      "small": {
+        "value": "{line-height.400}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{line-height.500}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{line-height.600}",
+        "type": "number"
+      }
+    }
+  },
+  "opacity": {
+    "zero": {
+      "value": 0,
+      "type": "number",
+      "description": "Dev only"
+    },
+    "disabled": {
+      "value": "{opacity.300}",
+      "type": "number",
+      "description": "Disabled states"
+    },
+    "overlay": {
+      "value": "{opacity.400}",
+      "type": "number",
+      "description": "Overlay"
+    },
+    "transclucent": {
+      "value": "{opacity.500}",
+      "type": "number",
+      "description": "Tooltips, Status Indicator"
+    },
+    "full": {
+      "value": 1,
+      "type": "number",
+      "description": "Dev only"
+    },
+    "shadow": {
+      "first": {
+        "value": "{opacity.200}",
+        "type": "number",
+        "description": "Alpha on first shadow"
+      },
+      "second": {
+        "value": "{opacity.100}",
+        "type": "number",
+        "description": "Alpha on second shadow"
+      }
+    }
+  },
+  "breakpoints": {
+    "zero": {
+      "value": 0,
+      "type": "number",
+      "description": "Use to set a media query `min-width` below small."
+    },
+    "s": {
+      "value": 320,
+      "type": "number",
+      "description": "The `min-width` for mobile devices, such as phones and tablets."
+    },
+    "m": {
+      "value": 768,
+      "type": "number",
+      "description": "Medium screens, such as laptops."
+    },
+    "l": {
+      "value": 1024,
+      "type": "number",
+      "description": "Large screens, such as desktops."
+    },
+    "xl": {
+      "value": 1440,
+      "type": "number",
+      "description": "Used for extra large screens, such as wide monitors and TVs."
+    }
+  },
+  "shape": {
+    "zero": {
+      "value": 0,
+      "type": "number"
+    },
+    "half": {
+      "value": 2,
+      "type": "number"
+    },
+    "x1": {
+      "value": "{base.unit}",
+      "type": "number"
+    },
+    "x1-half": {
+      "value": 6,
+      "type": "number"
+    },
+    "x2": {
+      "value": 8,
+      "type": "number"
+    },
+    "x4": {
+      "value": 16,
+      "type": "number"
+    },
+    "x6": {
+      "value": 24,
+      "type": "number"
+    },
+    "round": {
+      "value": 1000,
+      "type": "number"
     }
   }
 }


### PR DESCRIPTION
### What's been done

1. Replaced base palette with new color palette defined in OKLCH. I structured these tokens based off of the updated [Design Tokens W3C Color Module](https://tr.designtokens.org/color/), which might not work with our setup. Personally I think it's nice as it let's us define fallback srgb as part of the `$value`. 

If this structure doesn't work, another option is to follow our previous structure using oklch, and add the fallback in the description?

{
  "red": {
    "25": {
      "value": "oklch(98.5% 0.04 25.5)",
      "type": "color",
     "description": "#FFFFFF" (just as an example)
    }
}

3. Remapped brand and system color tokens to use the new set of base colors. This includes shadows (depth), and linear-gradients (brand), which I imagine might need some changes to work.

### Open questions

1. Will this work with our transformers? Can it?
2. Can we define srgb fallbacks using `hex`? All colors should already be within the `display-p3` gamut, the fallback value is what we'd like older browser to use with [@supports](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports)
4. Transparency - `rgba({token_name}, {opacity})` will no longer work - `oklch([L, C, H] / {opacity} `) instead?