### PR TITLE
feat: Add base tokens for spacing

### DIFF
--- a/tokens/base.json
+++ b/tokens/base.json
@@ -1616,6 +1616,16 @@
       "value": "0.25rem",
       "type": "dimension",
       "description": "The base unit used in the grid system.\n"
+    },
+    "fontSize": {
+      "value": "1rem",
+      "type": dimension",
+      "description": "Default fontSize"
+    },
+    "baseline": {
+      "value": "{base.fontSize} * 0.5",
+      "type": dimension",
+      "description": "8pt baseline grid"
     }
   },
   "font-size": {

--- a/tokens/base.json
+++ b/tokens/base.json
@@ -1619,12 +1619,12 @@
     },
     "fontSize": {
       "value": "1rem",
-      "type": dimension",
+      "type": "dimension",
       "description": "Default fontSize"
     },
     "baseline": {
       "value": "{base.fontSize} * 0.5",
-      "type": dimension",
+      "type": "dimension",
       "description": "8pt baseline grid"
     }
   },

--- a/tokens/sys/space.json
+++ b/tokens/sys/space.json
@@ -1,9 +1,74 @@
 {
   "space": {
-    "zero": {
+        "0": {
       "value": "0",
       "type": "spacing",
       "description": "Stacks, rows in tables"
+    },
+    "25": {
+      "value": "{base.baseline} * 0.25",
+      "type": "spacing",
+      "description": "Mobile only"
+    },
+    "50": {
+      "value": "{base.baseline} * 0.50",
+      "type": "spacing",
+      "description": "Compact spacing between text or icons"
+    },
+    "100": {
+      "value": "{base.baseline} * 1.00",
+      "type": "spacing",
+      "description": "Commonly used to group compact elements like icon buttons"
+    },
+    "150": {
+      "value": "{base.baseline} * 1.50",
+      "type": "spacing",
+      "description": "Use when compact padding is required"
+    },
+    "200": {
+      "value": "{base.baseline} * 2.00",
+      "type": "spacing",
+      "description": "Default space token. Used to group Inputs with related data"
+    },
+    "250": {
+      "value": "{base.baseline} * 2.50",
+      "type": "spacing",
+      "description": "Mobile only"
+    },
+    "300": {
+      "value": "{base.baseline} * 3.00",
+      "type": "spacing",
+      "description": "• Padding around card content\n• Related elements where more space between them can be afforded\n• Separate section headings or titles from body text or inputs"
+    },
+    "400": {
+      "value": "{base.baseline} * 4.00",
+      "type": "spacing",
+      "description": "• Standard spacing between cards\n• Used to separate groups of content \n• Separate section headings or titles from body text or inputs"
+    },
+    "500": {
+      "value": "{base.baseline} * 5.00",
+      "type": "spacing",
+      "description": "• Used for outer margins on the overall page content \n• Used for inner margins on large items such as page sections"
+    },
+    "700": {
+      "value": "{base.unit} * 7.00",
+      "type": "spacing",
+      "description": "Mobile only"
+    },
+    "800": {
+      "value": "{base.unit} * 8.00",
+      "type": "spacing",
+      "description": "- Use to de-clutter your UI when a lot of space is available\n- Separate banner sections from page content\n- Use to differentiate page content like page sections"
+    },
+    "1000": {
+      "value": "{base.unit} * 10.00",
+      "type": "spacing",
+      "description": "- Use sparingly\n- Helps to put focus on the primary element within your page\n- Use to de-clutter your UI when a lot of space is available"
+    },
+    "zero": {
+      "value": "0",
+      "type": "spacing",
+      "description": "Stacks, rows in tables",
     },
     "half": {
       "value": "{base.unit} * 0.5",

--- a/tokens/sys/space.json
+++ b/tokens/sys/space.json
@@ -1,6 +1,6 @@
 {
   "space": {
-        "0": {
+    "0": {
       "value": "0",
       "type": "spacing",
       "description": "Stacks, rows in tables"
@@ -68,7 +68,7 @@
     "zero": {
       "value": "0",
       "type": "spacing",
-      "description": "Stacks, rows in tables",
+      "description": "Stacks, rows in tables"
     },
     "half": {
       "value": "{base.unit} * 0.5",


### PR DESCRIPTION
### Base

Adding two base tokens for new space tokens to be built from.

`base.fontSize` is the default font size (16px/1rem). `base.baseline` is for the baseline grid to align to. We can probably mark `base.unit` as deprecated in the future (if we want), as `baseline` is essentially it's replacement. We are just making the relationship to the 8pt grid clearer for space/size tokens.

### System

Adding new space tokens with updated naming convention. Space tokens are named with numeric values (25, 50, 100, 200, 300 .. 1000) that map to multipliers of the `baseline` token. This is so that in-between values like 2 and 6 can use clean names that scale, like space-25, space-75 instead of space-xhalf.

The relationship between the baseline and space tokens looks like:

`fontSize` = 16px (1rem)
`baseline` = 8px (0.5rem)

`space.25` = `baseline` * 0.25 = 2
`space.50` = `baseline` * 0.50 = 4
`space.75` = `baseline` * 0.75 = 6
`space.100` = `baseline` * 1.00 = 8
...
`space.400` = `baseline` * 4.00 = 32
...
`space.1000` = `baseline` * 10.00 = 80

Where all the step value is used to create a normalized multiplier (1000/100) = 10.00, which is multiplied against the baseline (8pts). This allows us to use cleaner in-between values. Note: Our space tokens should really be considered `primitive` base tokens that serve the function of ensuring alignment to the baseline grid. In the future, we should consider adding semantic space tokens, such as:

`padding.large`, `space.between-cards`, `space.between-sections`, `space.icon-to-text`, etc.
