### PR TITLE
feat: transparent tokens

### DIFF
--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -1,1102 +1,1105 @@
 {
-  "color": {
-    "bg": {
-      "default": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Main background color"
-      },
-      "transparent": {
-        "value": "oklch({palette.neutral.0} / {opacity.0})",
-        "type": "color",
-        "description": "Transparent background"
-      },
-      "overlay": {
-        "value": "oklch({palette.neutral.1000} / {opacity.400})",
-        "type": "color",
-        "description": "Overlay background"
-      },
-      "translucent": {
-        "value": "oklch({palette.neutral.1000} / {opacity.500})",
-        "type": "color",
-        "description": "Tooltip, Status Indicator"
-      },
-      "translucent-inverse": {
-        "value": "oklch({palette.neutral.1000} / {opacity.250})",
-        "type": "color"
-      },
-      "overlay-inverse": {
-        "value": "oklch({palette.neutral.1000} / {opacity.200})",
-        "type": "color",
-        "comment": "Inverse overlay background"
-      },
-      "alt": {
-        "default": {
-          "value": "{palette.slate.100}",
-          "type": "color",
-          "description": "Surface hover, Secondary surfaces"
+    "color": {
+        "bg": {
+            "default": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Main background color"
+            },
+            "transparent": {
+                "default": {
+                    "value": "oklch({palette.neutral.1000} / {opacity.0})",
+                    "type": "color",
+                    "description": "Transparent background"
+                },
+                "strong": {
+                    "value": "oklch({palette.neutral.1000} / {opacity.200})",
+                    "type": "color",
+                    "comment": "Inverse Secondary Button Hover state"
+                },
+                "stronger": {
+                    "value": "oklch({palette.neutral.1000} / {opacity.250})",
+                    "type": "color",
+                    "comment": "Inverse Secondary Button Active state"
+                }
+            },
+            "overlay": {
+                "value": "oklch({palette.neutral.1000} / {opacity.400})",
+                "type": "color",
+                "description": "Overlay background"
+            },
+            "translucent": {
+                "value": "oklch({palette.neutral.1000} / {opacity.500})",
+                "type": "color",
+                "description": "Tooltip, Status Indicator"
+            },
+            "alt": {
+                "default": {
+                    "value": "{palette.slate.100}",
+                    "type": "color",
+                    "description": "Surface hover, Secondary surfaces"
+                },
+                "soft": {
+                    "value": "{palette.slate.50}",
+                    "type": "color",
+                    "description": "Alternative page background"
+                },
+                "strong": {
+                    "value": "{palette.slate.200}",
+                    "type": "color",
+                    "description": "Active states"
+                },
+                "stronger": {
+                    "value": "{palette.slate.300}",
+                    "type": "color",
+                    "description": "Active state for segmented control, Pill"
+                },
+                "softer": {
+                    "value": "{palette.slate.25}",
+                    "type": "color",
+                    "description": "Disabled inputs"
+                }
+            },
+            "muted": {
+                "soft": {
+                    "value": "{palette.slate.500}",
+                    "type": "color"
+                },
+                "default": {
+                    "value": "{palette.slate.600}",
+                    "type": "color"
+                },
+                "strong": {
+                    "value": "{palette.slate.700}",
+                    "type": "color"
+                },
+                "softer": {
+                    "value": "{palette.slate.400}",
+                    "type": "color"
+                }
+            },
+            "contrast": {
+                "default": {
+                    "value": "{palette.neutral.900}",
+                    "type": "color",
+                    "description": "Contrast backgrounds, like Secondary Buttons"
+                },
+                "strong": {
+                    "value": "{palette.neutral.950}",
+                    "type": "color",
+                    "description": "Contrast backgrounds, like Secondary Buttons"
+                }
+            },
+            "primary": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Primary brand color"
+                },
+                "softer": {
+                    "value": "{palette.blue.50}",
+                    "type": "color",
+                    "description": "Select"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Brand hover background"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Brand active background"
+                },
+                "softest": {
+                    "value": "{palette.blue.25}",
+                    "type": "color",
+                    "description": "Surface"
+                },
+                "soft": {
+                    "value": "{palette.blue.100}",
+                    "type": "color",
+                    "description": "Disabled"
+                }
+            },
+            "positive": {
+                "default": {
+                    "value": "{palette.green.600}",
+                    "type": "color",
+                    "description": "Disabled success background"
+                },
+                "strong": {
+                    "value": "{palette.green.700}",
+                    "type": "color",
+                    "description": "Hover success background"
+                },
+                "stronger": {
+                    "value": "{palette.green.800}",
+                    "type": "color",
+                    "description": "Active success background"
+                },
+                "softest": {
+                    "value": "{palette.green.25}",
+                    "type": "color",
+                    "description": "Lightest surface success background"
+                },
+                "soft": {
+                    "value": "{palette.green.100}",
+                    "type": "color",
+                    "description": "Disabled success background"
+                },
+                "softer": {
+                    "value": "{palette.green.50}",
+                    "type": "color",
+                    "description": "Surface success background"
+                }
+            },
+            "caution": {
+                "default": {
+                    "value": "{palette.amber.400}",
+                    "type": "color",
+                    "description": "Default warning background"
+                },
+                "softest": {
+                    "value": "{palette.amber.25}",
+                    "type": "color",
+                    "description": "Disabled warning background"
+                },
+                "strong": {
+                    "value": "{palette.amber.500}",
+                    "type": "color",
+                    "description": "Strong warning background"
+                },
+                "stronger": {
+                    "value": "{palette.amber.600}",
+                    "type": "color",
+                    "description": "Stronger warning background"
+                },
+                "softer": {
+                    "value": "{palette.amber.50}",
+                    "type": "color",
+                    "description": "Softer warning background"
+                },
+                "soft": {
+                    "value": "{palette.amber.100}",
+                    "type": "color",
+                    "description": "Softer warning background"
+                }
+            },
+            "critical": {
+                "default": {
+                    "value": "{palette.red.600}",
+                    "type": "color",
+                    "description": "Default error background"
+                },
+                "softest": {
+                    "value": "{palette.red.25}",
+                    "type": "color",
+                    "description": "Input error background"
+                },
+                "strong": {
+                    "value": "{palette.red.700}",
+                    "type": "color",
+                    "description": "Strong error background"
+                },
+                "stronger": {
+                    "value": "{palette.red.800}",
+                    "type": "color",
+                    "description": "Stronger error background"
+                },
+                "softer": {
+                    "value": "{palette.red.50}",
+                    "type": "color",
+                    "description": "Disabled error background"
+                },
+                "soft": {
+                    "value": "{palette.red.100}",
+                    "type": "color",
+                    "description": "Disabled error background"
+                }
+            },
+            "ai": {
+                "default": {
+                    "value": "{palette.blue.100}",
+                    "type": "color",
+                    "description": "AI container"
+                },
+                "strong": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Hover on AI container"
+                },
+                "stronger": {
+                    "value": "{palette.blue.400}",
+                    "type": "color",
+                    "description": "Active state on AI containers"
+                },
+                "strongest": {
+                    "value": "{palette.blue.950}",
+                    "type": "color",
+                    "description": "AI surfaces"
+                }
+            },
+            "info": {
+                "softest": {
+                    "value": "{palette.blue.25}",
+                    "type": "color",
+                    "description": "Surface"
+                },
+                "softer": {
+                    "value": "{palette.blue.50}",
+                    "type": "color",
+                    "description": "Select"
+                },
+                "soft": {
+                    "value": "{palette.blue.100}",
+                    "type": "color",
+                    "description": "Disabled"
+                },
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Primary brand color"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Brand hover background"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Brand active background"
+                }
+            }
         },
-        "soft": {
-          "value": "{palette.slate.50}",
-          "type": "color",
-          "description": "Alternative page background"
+        "text": {
+            "default": {
+                "value": "{palette.neutral.900}",
+                "type": "color",
+                "description": "Body text"
+            },
+            "disabled": {
+                "value": "{palette.slate.400}",
+                "type": "color",
+                "description": "Disabled text color"
+            },
+            "hint": {
+                "value": "{palette.slate.600}",
+                "type": "color",
+                "description": "Hint text color"
+            },
+            "strong": {
+                "value": "{palette.neutral.950}",
+                "type": "color",
+                "description": "Heading text"
+            },
+            "stronger": {
+                "value": "{palette.neutral.975}",
+                "type": "color",
+                "description": "Display text"
+            },
+            "inverse": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Inverse text color"
+            },
+            "critical": {
+                "default": {
+                    "value": "{palette.red.600}",
+                    "type": "color",
+                    "description": "Error text"
+                },
+                "strong": {
+                    "value": "{palette.red.700}",
+                    "type": "color",
+                    "description": "Error text"
+                },
+                "stronger": {
+                    "value": "{palette.red.800}",
+                    "type": "color",
+                    "description": "Error text"
+                },
+                "soft": {
+                    "value": "{palette.red.400}",
+                    "type": "color",
+                    "description": "Error text"
+                },
+                "softer": {
+                    "value": "{palette.red.200}",
+                    "type": "color",
+                    "description": "Error text"
+                }
+            },
+            "primary": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Branded text"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Branded hover text"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "soft": {
+                    "value": "{palette.blue.400}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "softer": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Active links"
+                }
+            },
+            "caution": {
+                "default": {
+                    "value": "{palette.amber.900}",
+                    "type": "color",
+                    "description": "Warning text"
+                },
+                "strong": {
+                    "value": "{palette.amber.950}",
+                    "type": "color",
+                    "description": "Strong warning text"
+                },
+                "soft": {
+                    "value": "{palette.amber.700}",
+                    "type": "color",
+                    "description": "Strong warning text"
+                },
+                "stronger": {
+                    "value": "{palette.amber.975}",
+                    "type": "color",
+                    "description": "Strong warning text"
+                },
+                "softer": {
+                    "value": "{palette.amber.500}",
+                    "type": "color",
+                    "description": "Strong warning text"
+                }
+            },
+            "ai": {
+                "value": "{palette.blue.950}",
+                "type": "color"
+            },
+            "positive": {
+                "default": {
+                    "value": "{palette.green.600}",
+                    "type": "color",
+                    "description": "Branded text"
+                },
+                "strong": {
+                    "value": "{palette.green.700}",
+                    "type": "color",
+                    "description": "Branded hover text"
+                },
+                "stronger": {
+                    "value": "{palette.green.800}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "soft": {
+                    "value": "{palette.green.400}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "softer": {
+                    "value": "{palette.green.200}",
+                    "type": "color",
+                    "description": "Active links"
+                }
+            },
+            "info": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Branded text"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Branded hover text"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "soft": {
+                    "value": "{palette.blue.400}",
+                    "type": "color",
+                    "description": "Active links"
+                },
+                "softer": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Active links"
+                }
+            }
         },
-        "strong": {
-          "value": "{palette.slate.200}",
-          "type": "color",
-          "description": "Active states"
+        "icon": {
+            "default": {
+                "value": "{palette.neutral.900}",
+                "type": "color",
+                "description": "Default icon color"
+            },
+            "soft": {
+                "value": "{palette.slate.600}",
+                "type": "color",
+                "description": "Disabled icon color"
+            },
+            "strong": {
+                "value": "{palette.neutral.950}",
+                "type": "color",
+                "description": "Hover icon color"
+            },
+            "inverse": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Inverse icon color"
+            },
+            "primary": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Brand icon color"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                },
+                "soft": {
+                    "value": "{palette.blue.400}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                },
+                "softer": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                }
+            },
+            "positive": {
+                "default": {
+                    "value": "{palette.green.600}",
+                    "type": "color",
+                    "description": "Success icon color"
+                },
+                "strong": {
+                    "value": "{palette.green.700}",
+                    "type": "color",
+                    "description": "Success icon color"
+                },
+                "stronger": {
+                    "value": "{palette.green.800}",
+                    "type": "color",
+                    "description": "Success icon color"
+                },
+                "soft": {
+                    "value": "{palette.green.400}",
+                    "type": "color",
+                    "description": "Success icon color"
+                },
+                "softer": {
+                    "value": "{palette.green.200}",
+                    "type": "color",
+                    "description": "Success icon color"
+                }
+            },
+            "critical": {
+                "default": {
+                    "value": "{palette.red.600}",
+                    "type": "color",
+                    "description": "Error icon color"
+                },
+                "strong": {
+                    "value": "{palette.red.700}",
+                    "type": "color",
+                    "description": "Error icon color"
+                },
+                "stronger": {
+                    "value": "{palette.red.800}",
+                    "type": "color",
+                    "description": "Error icon color"
+                },
+                "soft": {
+                    "value": "{palette.red.400}",
+                    "type": "color",
+                    "description": "Error icon color"
+                },
+                "softer": {
+                    "value": "{palette.red.200}",
+                    "type": "color",
+                    "description": "Error icon color"
+                }
+            },
+            "caution": {
+                "default": {
+                    "value": "{palette.amber.900}",
+                    "type": "color",
+                    "description": "Caution icon color"
+                },
+                "strong": {
+                    "value": "{palette.amber.950}",
+                    "type": "color",
+                    "description": "Strong caution icon color"
+                },
+                "stronger": {
+                    "value": "{palette.amber.975}",
+                    "type": "color",
+                    "description": "Strong caution icon color"
+                },
+                "soft": {
+                    "value": "{palette.amber.700}",
+                    "type": "color",
+                    "description": "Strong caution icon color"
+                },
+                "softer": {
+                    "value": "{palette.amber.500}",
+                    "type": "color",
+                    "description": "Strong caution icon color"
+                }
+            },
+            "disabled": {
+                "value": "{palette.slate.400}",
+                "type": "color",
+                "description": "Disabled icon color"
+            },
+            "info": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Brand icon color"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Stronger brand icon color"
+                }
+            }
         },
-        "stronger": {
-          "value": "{palette.slate.300}",
-          "type": "color",
-          "description": "Active state for segmented control, Pill"
+        "fg": {
+            "default": {
+                "value": "{palette.neutral.900}",
+                "type": "color",
+                "description": "Body"
+            },
+            "strong": {
+                "value": "{palette.neutral.950}",
+                "type": "color",
+                "description": "Headings"
+            },
+            "stronger": {
+                "value": "{palette.neutral.975}",
+                "type": "color",
+                "description": "Heading on hover"
+            },
+            "disabled": {
+                "value": "{palette.slate.400}",
+                "type": "color",
+                "description": "Disabled"
+            },
+            "inverse": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Inverse"
+            },
+            "critical": {
+                "default": {
+                    "value": "{palette.red.600}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "strong": {
+                    "value": "{palette.red.700}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "stronger": {
+                    "value": "{palette.red.800}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "soft": {
+                    "value": "{palette.red.400}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "softer": {
+                    "value": "{palette.red.200}",
+                    "type": "color",
+                    "description": "Error"
+                }
+            },
+            "muted": {
+                "default": {
+                    "value": "{palette.slate.600}",
+                    "type": "color",
+                    "description": "Hint text"
+                },
+                "strong": {
+                    "value": "{palette.slate.700}",
+                    "type": "color"
+                },
+                "stronger": {
+                    "value": "{palette.slate.800}",
+                    "type": "color"
+                },
+                "soft": {
+                    "value": "{palette.slate.400}",
+                    "type": "color",
+                    "description": "Tab item foreground"
+                }
+            },
+            "primary": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Links, Accent"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Links on hover"
+                },
+                "soft": {
+                    "value": "{palette.blue.400}",
+                    "type": "color"
+                },
+                "softer": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Link Inverse, Disabled"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Links on hover"
+                }
+            },
+            "caution": {
+                "default": {
+                    "value": "{palette.amber.900}",
+                    "type": "color",
+                    "description": "Warning"
+                },
+                "strong": {
+                    "value": "{palette.amber.950}",
+                    "type": "color",
+                    "description": "Warning on hover"
+                },
+                "soft": {
+                    "value": "{palette.amber.700}",
+                    "type": "color",
+                    "description": "Warning"
+                },
+                "stronger": {
+                    "value": "{palette.amber.975}",
+                    "type": "color",
+                    "description": "Warning on hover"
+                },
+                "softer": {
+                    "value": "{palette.amber.200}",
+                    "type": "color",
+                    "description": "Warning"
+                }
+            },
+            "contrast": {
+                "default": {
+                    "value": "{palette.neutral.950}",
+                    "type": "color",
+                    "description": "Contrast"
+                },
+                "strong": {
+                    "value": "{palette.neutral.975}",
+                    "type": "color",
+                    "description": "Strong contrast"
+                }
+            },
+            "ai": {
+                "value": "{palette.blue.950}",
+                "type": "color",
+                "description": "AI icons and text"
+            },
+            "info": {
+                "softer": {
+                    "value": "{palette.blue.200}",
+                    "type": "color",
+                    "description": "Link Inverse, Disabled"
+                },
+                "soft": {
+                    "value": "{palette.blue.400}",
+                    "type": "color"
+                },
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Links, Accent"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Links on hover"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Links on hover"
+                }
+            },
+            "positive": {
+                "default": {
+                    "value": "{palette.green.600}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "softer": {
+                    "value": "{palette.green.200}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "soft": {
+                    "value": "{palette.green.400}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "strong": {
+                    "value": "{palette.green.700}",
+                    "type": "color",
+                    "description": "Error"
+                },
+                "stronger": {
+                    "value": "{palette.green.800}",
+                    "type": "color",
+                    "description": "Error"
+                }
+            }
         },
-        "softer": {
-          "value": "{palette.slate.25}",
-          "type": "color",
-          "description": "Disabled inputs"
+        "border": {
+            "input": {
+                "disabled": {
+                    "value": "{palette.slate.400}",
+                    "type": "color",
+                    "description": "Disabled inputs"
+                },
+                "default": {
+                    "value": "{palette.slate.500}",
+                    "type": "color",
+                    "description": "Inputs"
+                },
+                "strong": {
+                    "value": "{palette.slate.700}",
+                    "type": "color",
+                    "description": "Input hover"
+                },
+                "inverse": {
+                    "value": "{palette.neutral.0}",
+                    "type": "color",
+                    "description": "Borders on checkboxes and radios"
+                }
+            },
+            "contrast": {
+                "default": {
+                    "value": "{palette.neutral.900}",
+                    "type": "color",
+                    "description": "Secondary Button"
+                },
+                "strong": {
+                    "value": "{palette.neutral.950}",
+                    "type": "color",
+                    "description": "Secondary Button Hover"
+                }
+            },
+            "primary": {
+                "default": {
+                    "value": "{palette.blue.500}",
+                    "type": "color",
+                    "description": "Brand, Focus"
+                }
+            },
+            "critical": {
+                "default": {
+                    "value": "{palette.red.500}",
+                    "type": "color",
+                    "description": "Error"
+                }
+            },
+            "caution": {
+                "default": {
+                    "value": "{palette.amber.400}",
+                    "type": "color",
+                    "description": "Warning inner"
+                },
+                "strong": {
+                    "value": "{palette.amber.500}",
+                    "type": "color",
+                    "description": "Warning outer (box shadow)"
+                }
+            },
+            "transparent": {
+                "value": "oklch({palette.neutral.0} / {opacity.0})",
+                "type": "color",
+                "description": "Transparent"
+            },
+            "inverse": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Borders on accent colors"
+            },
+            "divider": {
+                "value": "{palette.slate.200}",
+                "type": "color",
+                "description": "Dividers"
+            },
+            "container": {
+                "value": "{palette.slate.300}",
+                "type": "color",
+                "description": "Cards, Toasts, Surfaces"
+            },
+            "ai": {
+                "value": "{palette.blue.950}",
+                "type": "color",
+                "description": "Active state on AI borders"
+            },
+            "info": {
+                "default": {
+                    "value": "{palette.blue.500}",
+                    "type": "color",
+                    "description": "Brand, Focus"
+                }
+            }
+        },
+        "shadow": {
+            "1": {
+                "value": "oklch({palette.slate.900} / {opacity.200})",
+                "type": "color",
+                "description": "First shadow color"
+            },
+            "2": {
+                "value": "oklch({palette.slate.900} / {opacity.100})",
+                "type": "color",
+                "description": "Second shadow color"
+            },
+            "default": {
+                "value": "{palette.slate.900}",
+                "type": "color",
+                "description": "Main shadow color"
+            }
+        },
+        "static": {
+            "blue": {
+                "default": {
+                    "value": "{palette.blue.600}",
+                    "type": "color",
+                    "description": "Blue"
+                },
+                "softest": {
+                    "value": "{palette.blue.25}",
+                    "type": "color",
+                    "description": "Light blue"
+                },
+                "strong": {
+                    "value": "{palette.blue.700}",
+                    "type": "color",
+                    "description": "Stronger blue"
+                },
+                "stronger": {
+                    "value": "{palette.blue.800}",
+                    "type": "color",
+                    "description": "Stronger blue"
+                },
+                "softer": {
+                    "value": "{palette.blue.50}",
+                    "type": "color",
+                    "description": "Light blue"
+                },
+                "soft": {
+                    "value": "{palette.blue.100}",
+                    "type": "color",
+                    "description": "Light blue"
+                },
+                "strongest": {
+                    "value": "{palette.blue.950}",
+                    "type": "color",
+                    "description": "Stronger blue"
+                }
+            },
+            "green": {
+                "default": {
+                    "value": "{palette.green.600}",
+                    "type": "color",
+                    "description": "Default green"
+                },
+                "soft": {
+                    "value": "{palette.green.100}",
+                    "type": "color",
+                    "description": "Light green"
+                },
+                "strong": {
+                    "value": "{palette.green.700}",
+                    "type": "color",
+                    "description": "Stronger green"
+                },
+                "softer": {
+                    "value": "{palette.green.50}",
+                    "type": "color",
+                    "description": "Light green"
+                },
+                "stronger": {
+                    "value": "{palette.green.800}",
+                    "type": "color",
+                    "description": "Stronger green"
+                },
+                "softest": {
+                    "value": "{palette.green.25}",
+                    "type": "color",
+                    "description": "Light green"
+                },
+                "strongest": {
+                    "value": "{palette.green.950}",
+                    "type": "color",
+                    "description": "Stronger green"
+                }
+            },
+            "red": {
+                "default": {
+                    "value": "{palette.red.600}",
+                    "type": "color",
+                    "description": "Red"
+                },
+                "soft": {
+                    "value": "{palette.red.100}",
+                    "type": "color",
+                    "description": "Light red"
+                },
+                "strong": {
+                    "value": "{palette.red.700}",
+                    "type": "color",
+                    "description": "Strong red"
+                },
+                "stronger": {
+                    "value": "{palette.red.800}",
+                    "type": "color",
+                    "description": "Strong red"
+                },
+                "softest": {
+                    "value": "{palette.red.25}",
+                    "type": "color",
+                    "description": "Light red"
+                },
+                "strongest": {
+                    "value": "{palette.red.950}",
+                    "type": "color",
+                    "description": "Strong red"
+                },
+                "softer": {
+                    "value": "{palette.red.50}",
+                    "type": "color",
+                    "description": "Light red"
+                }
+            },
+            "white": {
+                "value": "{palette.neutral.0}",
+                "type": "color",
+                "description": "Just white"
+            },
+            "black": {
+                "value": "{palette.neutral.1000}",
+                "type": "color",
+                "description": "Just black"
+            },
+            "gray": {
+                "default": {
+                    "value": "{palette.slate.600}",
+                    "type": "color",
+                    "description": "Gray"
+                },
+                "soft": {
+                    "value": "{palette.slate.200}",
+                    "type": "color",
+                    "description": "Light gray"
+                },
+                "strong": {
+                    "value": "{palette.slate.700}",
+                    "type": "color",
+                    "description": "Stronger gray"
+                },
+                "stronger": {
+                    "value": "{palette.slate.800}",
+                    "type": "color",
+                    "description": "Strongerer gray"
+                },
+                "strongest": {
+                    "value": "{palette.slate.950}",
+                    "type": "color",
+                    "description": "Strongerer gray"
+                },
+                "softest": {
+                    "value": "{palette.slate.50}",
+                    "type": "color",
+                    "description": "Light gray"
+                },
+                "softer": {
+                    "value": "{palette.slate.100}",
+                    "type": "color",
+                    "description": "Light gray"
+                }
+            },
+            "amber": {
+                "default": {
+                    "value": "{palette.amber.400}",
+                    "type": "color",
+                    "description": "amber"
+                },
+                "softest": {
+                    "value": "{palette.amber.25}",
+                    "type": "color",
+                    "description": "Soft amber"
+                },
+                "strong": {
+                    "value": "{palette.amber.500}",
+                    "type": "color",
+                    "description": "Stronger amber"
+                },
+                "stronger": {
+                    "value": "{palette.amber.600}",
+                    "type": "color",
+                    "description": "Stronger amber"
+                },
+                "softer": {
+                    "value": "{palette.amber.50}",
+                    "type": "color",
+                    "description": "Soft amber"
+                },
+                "strongest": {
+                    "value": "{palette.amber.950}",
+                    "type": "color",
+                    "description": "Stronger amber"
+                },
+                "soft": {
+                    "value": "{palette.amber.100}",
+                    "type": "color",
+                    "description": "Soft amber"
+                }
+            }
         }
-      },
-      "muted": {
-        "soft": {
-          "value": "{palette.slate.500}",
-          "type": "color"
-        },
-        "default": {
-          "value": "{palette.slate.600}",
-          "type": "color"
-        },
-        "strong": {
-          "value": "{palette.slate.700}",
-          "type": "color"
-        },
-        "softer": {
-          "value": "{palette.slate.400}",
-          "type": "color"
-        }
-      },
-      "contrast": {
-        "default": {
-          "value": "{palette.neutral.900}",
-          "type": "color",
-          "description": "Contrast backgrounds, like Secondary Buttons"
-        },
-        "strong": {
-          "value": "{palette.neutral.950}",
-          "type": "color",
-          "description": "Contrast backgrounds, like Secondary Buttons"
-        }
-      },
-      "primary": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Primary brand color"
-        },
-        "softer": {
-          "value": "{palette.blue.50}",
-          "type": "color",
-          "description": "Select"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Brand hover background"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Brand active background"
-        },
-        "softest": {
-          "value": "{palette.blue.25}",
-          "type": "color",
-          "description": "Surface"
-        },
-        "soft": {
-          "value": "{palette.blue.100}",
-          "type": "color",
-          "description": "Disabled"
-        }
-      },
-      "positive": {
-        "default": {
-          "value": "{palette.green.600}",
-          "type": "color",
-          "description": "Disabled success background"
-        },
-        "strong": {
-          "value": "{palette.green.700}",
-          "type": "color",
-          "description": "Hover success background"
-        },
-        "stronger": {
-          "value": "{palette.green.800}",
-          "type": "color",
-          "description": "Active success background"
-        },
-        "softest": {
-          "value": "{palette.green.25}",
-          "type": "color",
-          "description": "Lightest surface success background"
-        },
-        "soft": {
-          "value": "{palette.green.100}",
-          "type": "color",
-          "description": "Disabled success background"
-        },
-        "softer": {
-          "value": "{palette.green.50}",
-          "type": "color",
-          "description": "Surface success background"
-        }
-      },
-      "caution": {
-        "default": {
-          "value": "{palette.amber.400}",
-          "type": "color",
-          "description": "Default warning background"
-        },
-        "softest": {
-          "value": "{palette.amber.25}",
-          "type": "color",
-          "description": "Disabled warning background"
-        },
-        "strong": {
-          "value": "{palette.amber.500}",
-          "type": "color",
-          "description": "Strong warning background"
-        },
-        "stronger": {
-          "value": "{palette.amber.600}",
-          "type": "color",
-          "description": "Stronger warning background"
-        },
-        "softer": {
-          "value": "{palette.amber.50}",
-          "type": "color",
-          "description": "Softer warning background"
-        },
-        "soft": {
-          "value": "{palette.amber.100}",
-          "type": "color",
-          "description": "Softer warning background"
-        }
-      },
-      "critical": {
-        "default": {
-          "value": "{palette.red.600}",
-          "type": "color",
-          "description": "Default error background"
-        },
-        "softest": {
-          "value": "{palette.red.25}",
-          "type": "color",
-          "description": "Input error background"
-        },
-        "strong": {
-          "value": "{palette.red.700}",
-          "type": "color",
-          "description": "Strong error background"
-        },
-        "stronger": {
-          "value": "{palette.red.800}",
-          "type": "color",
-          "description": "Stronger error background"
-        },
-        "softer": {
-          "value": "{palette.red.50}",
-          "type": "color",
-          "description": "Disabled error background"
-        },
-        "soft": {
-          "value": "{palette.red.100}",
-          "type": "color",
-          "description": "Disabled error background"
-        }
-      },
-      "ai": {
-        "default": {
-          "value": "{palette.blue.100}",
-          "type": "color",
-          "description": "AI container"
-        },
-        "strong": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Hover on AI container"
-        },
-        "stronger": {
-          "value": "{palette.blue.400}",
-          "type": "color",
-          "description": "Active state on AI containers"
-        },
-        "strongest": {
-          "value": "{palette.blue.950}",
-          "type": "color",
-          "description": "AI surfaces"
-        }
-      },
-      "info": {
-        "softest": {
-          "value": "{palette.blue.25}",
-          "type": "color",
-          "description": "Surface"
-        },
-        "softer": {
-          "value": "{palette.blue.50}",
-          "type": "color",
-          "description": "Select"
-        },
-        "soft": {
-          "value": "{palette.blue.100}",
-          "type": "color",
-          "description": "Disabled"
-        },
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Primary brand color"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Brand hover background"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Brand active background"
-        }
-      }
-    },
-    "text": {
-      "default": {
-        "value": "{palette.neutral.900}",
-        "type": "color",
-        "description": "Body text"
-      },
-      "disabled": {
-        "value": "{palette.slate.400}",
-        "type": "color",
-        "description": "Disabled text color"
-      },
-      "hint": {
-        "value": "{palette.slate.600}",
-        "type": "color",
-        "description": "Hint text color"
-      },
-      "strong": {
-        "value": "{palette.neutral.950}",
-        "type": "color",
-        "description": "Heading text"
-      },
-      "stronger": {
-        "value": "{palette.neutral.975}",
-        "type": "color",
-        "description": "Display text"
-      },
-      "inverse": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Inverse text color"
-      },
-      "critical": {
-        "default": {
-          "value": "{palette.red.600}",
-          "type": "color",
-          "description": "Error text"
-        },
-        "strong": {
-          "value": "{palette.red.700}",
-          "type": "color",
-          "description": "Error text"
-        },
-        "stronger": {
-          "value": "{palette.red.800}",
-          "type": "color",
-          "description": "Error text"
-        },
-        "soft": {
-          "value": "{palette.red.400}",
-          "type": "color",
-          "description": "Error text"
-        },
-        "softer": {
-          "value": "{palette.red.200}",
-          "type": "color",
-          "description": "Error text"
-        }
-      },
-      "primary": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Branded text"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Branded hover text"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "soft": {
-          "value": "{palette.blue.400}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "softer": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Active links"
-        }
-      },
-      "caution": {
-        "default": {
-          "value": "{palette.amber.900}",
-          "type": "color",
-          "description": "Warning text"
-        },
-        "strong": {
-          "value": "{palette.amber.950}",
-          "type": "color",
-          "description": "Strong warning text"
-        },
-        "soft": {
-          "value": "{palette.amber.700}",
-          "type": "color",
-          "description": "Strong warning text"
-        },
-        "stronger": {
-          "value": "{palette.amber.975}",
-          "type": "color",
-          "description": "Strong warning text"
-        },
-        "softer": {
-          "value": "{palette.amber.500}",
-          "type": "color",
-          "description": "Strong warning text"
-        }
-      },
-      "ai": {
-        "value": "{palette.blue.950}",
-        "type": "color"
-      },
-      "positive": {
-        "default": {
-          "value": "{palette.green.600}",
-          "type": "color",
-          "description": "Branded text"
-        },
-        "strong": {
-          "value": "{palette.green.700}",
-          "type": "color",
-          "description": "Branded hover text"
-        },
-        "stronger": {
-          "value": "{palette.green.800}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "soft": {
-          "value": "{palette.green.400}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "softer": {
-          "value": "{palette.green.200}",
-          "type": "color",
-          "description": "Active links"
-        }
-      },
-      "info": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Branded text"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Branded hover text"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "soft": {
-          "value": "{palette.blue.400}",
-          "type": "color",
-          "description": "Active links"
-        },
-        "softer": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Active links"
-        }
-      }
-    },
-    "icon": {
-      "default": {
-        "value": "{palette.neutral.900}",
-        "type": "color",
-        "description": "Default icon color"
-      },
-      "soft": {
-        "value": "{palette.slate.600}",
-        "type": "color",
-        "description": "Disabled icon color"
-      },
-      "strong": {
-        "value": "{palette.neutral.950}",
-        "type": "color",
-        "description": "Hover icon color"
-      },
-      "inverse": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Inverse icon color"
-      },
-      "primary": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Brand icon color"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        },
-        "soft": {
-          "value": "{palette.blue.400}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        },
-        "softer": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        }
-      },
-      "positive": {
-        "default": {
-          "value": "{palette.green.600}",
-          "type": "color",
-          "description": "Success icon color"
-        },
-        "strong": {
-          "value": "{palette.green.700}",
-          "type": "color",
-          "description": "Success icon color"
-        },
-        "stronger": {
-          "value": "{palette.green.800}",
-          "type": "color",
-          "description": "Success icon color"
-        },
-        "soft": {
-          "value": "{palette.green.400}",
-          "type": "color",
-          "description": "Success icon color"
-        },
-        "softer": {
-          "value": "{palette.green.200}",
-          "type": "color",
-          "description": "Success icon color"
-        }
-      },
-      "critical": {
-        "default": {
-          "value": "{palette.red.600}",
-          "type": "color",
-          "description": "Error icon color"
-        },
-        "strong": {
-          "value": "{palette.red.700}",
-          "type": "color",
-          "description": "Error icon color"
-        },
-        "stronger": {
-          "value": "{palette.red.800}",
-          "type": "color",
-          "description": "Error icon color"
-        },
-        "soft": {
-          "value": "{palette.red.400}",
-          "type": "color",
-          "description": "Error icon color"
-        },
-        "softer": {
-          "value": "{palette.red.200}",
-          "type": "color",
-          "description": "Error icon color"
-        }
-      },
-      "caution": {
-        "default": {
-          "value": "{palette.amber.900}",
-          "type": "color",
-          "description": "Caution icon color"
-        },
-        "strong": {
-          "value": "{palette.amber.950}",
-          "type": "color",
-          "description": "Strong caution icon color"
-        },
-        "stronger": {
-          "value": "{palette.amber.975}",
-          "type": "color",
-          "description": "Strong caution icon color"
-        },
-        "soft": {
-          "value": "{palette.amber.700}",
-          "type": "color",
-          "description": "Strong caution icon color"
-        },
-        "softer": {
-          "value": "{palette.amber.500}",
-          "type": "color",
-          "description": "Strong caution icon color"
-        }
-      },
-      "disabled": {
-        "value": "{palette.slate.400}",
-        "type": "color",
-        "description": "Disabled icon color"
-      },
-      "info": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Brand icon color"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Stronger brand icon color"
-        }
-      }
-    },
-    "fg": {
-      "default": {
-        "value": "{palette.neutral.900}",
-        "type": "color",
-        "description": "Body"
-      },
-      "strong": {
-        "value": "{palette.neutral.950}",
-        "type": "color",
-        "description": "Headings"
-      },
-      "stronger": {
-        "value": "{palette.neutral.975}",
-        "type": "color",
-        "description": "Heading on hover"
-      },
-      "disabled": {
-        "value": "{palette.slate.400}",
-        "type": "color",
-        "description": "Disabled"
-      },
-      "inverse": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Inverse"
-      },
-      "critical": {
-        "default": {
-          "value": "{palette.red.600}",
-          "type": "color",
-          "description": "Error"
-        },
-        "strong": {
-          "value": "{palette.red.700}",
-          "type": "color",
-          "description": "Error"
-        },
-        "stronger": {
-          "value": "{palette.red.800}",
-          "type": "color",
-          "description": "Error"
-        },
-        "soft": {
-          "value": "{palette.red.400}",
-          "type": "color",
-          "description": "Error"
-        },
-        "softer": {
-          "value": "{palette.red.200}",
-          "type": "color",
-          "description": "Error"
-        }
-      },
-      "muted": {
-        "default": {
-          "value": "{palette.slate.600}",
-          "type": "color",
-          "description": "Hint text"
-        },
-        "strong": {
-          "value": "{palette.slate.700}",
-          "type": "color"
-        },
-        "stronger": {
-          "value": "{palette.slate.800}",
-          "type": "color"
-        },
-        "soft": {
-          "value": "{palette.slate.400}",
-          "type": "color",
-          "description": "Tab item foreground"
-        }
-      },
-      "primary": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Links, Accent"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Links on hover"
-        },
-        "soft": {
-          "value": "{palette.blue.400}",
-          "type": "color"
-        },
-        "softer": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Link Inverse, Disabled"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Links on hover"
-        }
-      },
-      "caution": {
-        "default": {
-          "value": "{palette.amber.900}",
-          "type": "color",
-          "description": "Warning"
-        },
-        "strong": {
-          "value": "{palette.amber.950}",
-          "type": "color",
-          "description": "Warning on hover"
-        },
-        "soft": {
-          "value": "{palette.amber.700}",
-          "type": "color",
-          "description": "Warning"
-        },
-        "stronger": {
-          "value": "{palette.amber.975}",
-          "type": "color",
-          "description": "Warning on hover"
-        },
-        "softer": {
-          "value": "{palette.amber.200}",
-          "type": "color",
-          "description": "Warning"
-        }
-      },
-      "contrast": {
-        "default": {
-          "value": "{palette.neutral.950}",
-          "type": "color",
-          "description": "Contrast"
-        },
-        "strong": {
-          "value": "{palette.neutral.975}",
-          "type": "color",
-          "description": "Strong contrast"
-        }
-      },
-      "ai": {
-        "value": "{palette.blue.950}",
-        "type": "color",
-        "description": "AI icons and text"
-      },
-      "info": {
-        "softer": {
-          "value": "{palette.blue.200}",
-          "type": "color",
-          "description": "Link Inverse, Disabled"
-        },
-        "soft": {
-          "value": "{palette.blue.400}",
-          "type": "color"
-        },
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Links, Accent"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Links on hover"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Links on hover"
-        }
-      },
-      "positive": {
-        "default": {
-          "value": "{palette.green.600}",
-          "type": "color",
-          "description": "Error"
-        },
-        "softer": {
-          "value": "{palette.green.200}",
-          "type": "color",
-          "description": "Error"
-        },
-        "soft": {
-          "value": "{palette.green.400}",
-          "type": "color",
-          "description": "Error"
-        },
-        "strong": {
-          "value": "{palette.green.700}",
-          "type": "color",
-          "description": "Error"
-        },
-        "stronger": {
-          "value": "{palette.green.800}",
-          "type": "color",
-          "description": "Error"
-        }
-      }
-    },
-    "border": {
-      "input": {
-        "disabled": {
-          "value": "{palette.slate.400}",
-          "type": "color",
-          "description": "Disabled inputs"
-        },
-        "default": {
-          "value": "{palette.slate.500}",
-          "type": "color",
-          "description": "Inputs"
-        },
-        "strong": {
-          "value": "{palette.slate.700}",
-          "type": "color",
-          "description": "Input hover"
-        },
-        "inverse": {
-          "value": "{palette.neutral.0}",
-          "type": "color",
-          "description": "Borders on checkboxes and radios"
-        }
-      },
-      "contrast": {
-        "default": {
-          "value": "{palette.neutral.900}",
-          "type": "color",
-          "description": "Secondary Button"
-        },
-        "strong": {
-          "value": "{palette.neutral.950}",
-          "type": "color",
-          "description": "Secondary Button Hover"
-        }
-      },
-      "primary": {
-        "default": {
-          "value": "{palette.blue.500}",
-          "type": "color",
-          "description": "Brand, Focus"
-        }
-      },
-      "critical": {
-        "default": {
-          "value": "{palette.red.500}",
-          "type": "color",
-          "description": "Error"
-        }
-      },
-      "caution": {
-        "default": {
-          "value": "{palette.amber.400}",
-          "type": "color",
-          "description": "Warning inner"
-        },
-        "strong": {
-          "value": "{palette.amber.500}",
-          "type": "color",
-          "description": "Warning outer (box shadow)"
-        }
-      },
-      "transparent": {
-        "value": "oklch({palette.neutral.0} / {opacity.0})",
-        "type": "color",
-        "description": "Transparent"
-      },
-      "inverse": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Borders on accent colors"
-      },
-      "divider": {
-        "value": "{palette.slate.200}",
-        "type": "color",
-        "description": "Dividers"
-      },
-      "container": {
-        "value": "{palette.slate.300}",
-        "type": "color",
-        "description": "Cards, Toasts, Surfaces"
-      },
-      "ai": {
-        "value": "{palette.blue.950}",
-        "type": "color",
-        "description": "Active state on AI borders"
-      },
-      "info": {
-        "default": {
-          "value": "{palette.blue.500}",
-          "type": "color",
-          "description": "Brand, Focus"
-        }
-      }
-    },
-    "shadow": {
-      "1": {
-        "value": "oklch({palette.slate.900} / {opacity.200})",
-        "type": "color",
-        "description": "First shadow color"
-      },
-      "2": {
-        "value": "oklch({palette.slate.900} / {opacity.100})",
-        "type": "color",
-        "description": "Second shadow color"
-      },
-      "default": {
-        "value": "{palette.slate.900}",
-        "type": "color",
-        "description": "Main shadow color"
-      }
-    },
-    "static": {
-      "blue": {
-        "default": {
-          "value": "{palette.blue.600}",
-          "type": "color",
-          "description": "Blue"
-        },
-        "softest": {
-          "value": "{palette.blue.25}",
-          "type": "color",
-          "description": "Light blue"
-        },
-        "strong": {
-          "value": "{palette.blue.700}",
-          "type": "color",
-          "description": "Stronger blue"
-        },
-        "stronger": {
-          "value": "{palette.blue.800}",
-          "type": "color",
-          "description": "Stronger blue"
-        },
-        "softer": {
-          "value": "{palette.blue.50}",
-          "type": "color",
-          "description": "Light blue"
-        },
-        "soft": {
-          "value": "{palette.blue.100}",
-          "type": "color",
-          "description": "Light blue"
-        },
-        "strongest": {
-          "value": "{palette.blue.950}",
-          "type": "color",
-          "description": "Stronger blue"
-        }
-      },
-      "green": {
-        "default": {
-          "value": "{palette.green.600}",
-          "type": "color",
-          "description": "Default green"
-        },
-        "soft": {
-          "value": "{palette.green.100}",
-          "type": "color",
-          "description": "Light green"
-        },
-        "strong": {
-          "value": "{palette.green.700}",
-          "type": "color",
-          "description": "Stronger green"
-        },
-        "softer": {
-          "value": "{palette.green.50}",
-          "type": "color",
-          "description": "Light green"
-        },
-        "stronger": {
-          "value": "{palette.green.800}",
-          "type": "color",
-          "description": "Stronger green"
-        },
-        "softest": {
-          "value": "{palette.green.25}",
-          "type": "color",
-          "description": "Light green"
-        },
-        "strongest": {
-          "value": "{palette.green.950}",
-          "type": "color",
-          "description": "Stronger green"
-        }
-      },
-      "red": {
-        "default": {
-          "value": "{palette.red.600}",
-          "type": "color",
-          "description": "Red"
-        },
-        "soft": {
-          "value": "{palette.red.100}",
-          "type": "color",
-          "description": "Light red"
-        },
-        "strong": {
-          "value": "{palette.red.700}",
-          "type": "color",
-          "description": "Strong red"
-        },
-        "stronger": {
-          "value": "{palette.red.800}",
-          "type": "color",
-          "description": "Strong red"
-        },
-        "softest": {
-          "value": "{palette.red.25}",
-          "type": "color",
-          "description": "Light red"
-        },
-        "strongest": {
-          "value": "{palette.red.950}",
-          "type": "color",
-          "description": "Strong red"
-        },
-        "softer": {
-          "value": "{palette.red.50}",
-          "type": "color",
-          "description": "Light red"
-        }
-      },
-      "white": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Just white"
-      },
-      "black": {
-        "value": "{palette.neutral.1000}",
-        "type": "color",
-        "description": "Just black"
-      },
-      "gray": {
-        "default": {
-          "value": "{palette.slate.600}",
-          "type": "color",
-          "description": "Gray"
-        },
-        "soft": {
-          "value": "{palette.slate.200}",
-          "type": "color",
-          "description": "Light gray"
-        },
-        "strong": {
-          "value": "{palette.slate.700}",
-          "type": "color",
-          "description": "Stronger gray"
-        },
-        "stronger": {
-          "value": "{palette.slate.800}",
-          "type": "color",
-          "description": "Strongerer gray"
-        },
-        "strongest": {
-          "value": "{palette.slate.950}",
-          "type": "color",
-          "description": "Strongerer gray"
-        },
-        "softest": {
-          "value": "{palette.slate.50}",
-          "type": "color",
-          "description": "Light gray"
-        },
-        "softer": {
-          "value": "{palette.slate.100}",
-          "type": "color",
-          "description": "Light gray"
-        }
-      },
-      "amber": {
-        "default": {
-          "value": "{palette.amber.400}",
-          "type": "color",
-          "description": "amber"
-        },
-        "softest": {
-          "value": "{palette.amber.25}",
-          "type": "color",
-          "description": "Soft amber"
-        },
-        "strong": {
-          "value": "{palette.amber.500}",
-          "type": "color",
-          "description": "Stronger amber"
-        },
-        "stronger": {
-          "value": "{palette.amber.600}",
-          "type": "color",
-          "description": "Stronger amber"
-        },
-        "softer": {
-          "value": "{palette.amber.50}",
-          "type": "color",
-          "description": "Soft amber"
-        },
-        "strongest": {
-          "value": "{palette.amber.950}",
-          "type": "color",
-          "description": "Stronger amber"
-        },
-        "soft": {
-          "value": "{palette.amber.100}",
-          "type": "color",
-          "description": "Soft amber"
-        }
-      }
     }
-  }
 }


### PR DESCRIPTION
Adding new transparency tokens for Hover and Active states of Inverse Secondary Buttons.

## Changes

We changed our bg.transparent color token to use black instead of white, and added a "default" suffix to the token to avoid JSON nesting bug. Changing it to black and fully transparent let us add two other variants for the hover and active states, strong and stronger.

We kept `bg.overlay` and `bg.transcluscent` the same - adding variants of those didn't make sense as we are not creating variants of modal with lighter scrims overlays, and these are not colors that are only slightly opaque.