### PR TITLE
fix: Update caution color mapping

### DIFF
--- a/.github/workflows/sync-tokens.yml
+++ b/.github/workflows/sync-tokens.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Commit changes
         if: ${{ steps.check_staged.outputs.has_staged == 'true' }}
         run: |
-          git commit -m "feat: Sync tokens from canvas-tokens-studio"
+          git commit -m "${{ github.event.head_commit.message }}"
 
       - name: Push changes
         if: ${{ steps.check_staged.outputs.has_staged == 'true' }}
@@ -124,7 +124,7 @@ jobs:
             github.rest.pulls.create({
               owner: 'Workday',
               repo: 'canvas-tokens',
-              title: 'feat: Sync tokens from canvas-tokens-studio',
+              title: ${{ github.event.head_commit.message }},
               head: '${{ steps.sync_branch.outputs.name }}',
               base: '${{ github.ref_name}}'
             });

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -372,7 +372,7 @@
         "soft": {
           "value": "{palette.amber.400}",
           "type": "color",
-          "description": "Strong warning text"
+          "description": "Disabled warning text"
         },
         "stronger": {
           "value": "{palette.amber.975}",
@@ -382,7 +382,7 @@
         "softer": {
           "value": "{palette.amber.200}",
           "type": "color",
-          "description": "Strong warning text"
+          "description": "Softer warning text"
         }
       },
       "ai": {
@@ -563,14 +563,14 @@
           "description": "Strong caution icon color"
         },
         "soft": {
-          "value": "{palette.amber.400}",
+          "value": "{palette.amber.700}",
           "type": "color",
-          "description": "Strong caution icon color"
+          "description": "Soft caution icon color"
         },
         "softer": {
-          "value": "{palette.amber.200}",
+          "value": "{palette.amber.500}",
           "type": "color",
-          "description": "Strong caution icon color"
+          "description": "Softer caution icon color"
         }
       },
       "disabled": {
@@ -707,7 +707,7 @@
           "description": "Warning on hover"
         },
         "soft": {
-          "value": "{palette.amber.400}",
+          "value": "{palette.amber.700}",
           "type": "color",
           "description": "Warning"
         },
@@ -717,7 +717,7 @@
           "description": "Warning on hover"
         },
         "softer": {
-          "value": "{palette.amber.200}",
+          "value": "{palette.amber.500}",
           "type": "color",
           "description": "Warning"
         }


### PR DESCRIPTION
We're reverting a few color changes introduced in v3.1.0. These are being updated to provide proper contrast for caution colors.