### PR TITLE
feat: Add new base size and shape tokens

### DIFF
--- a/tokens/base.json
+++ b/tokens/base.json
@@ -1615,123 +1615,308 @@
     "unit": {
       "value": "0.25rem",
       "type": "dimension",
-      "description": "The base unit used in the grid system.\n"
+      "description": "The base unit used for the typographic grid system.\n",
+	  "deprecated": true,
+	  "deprecatedComment": "Use {base.baseline} instead for consistent sizing calculations"
+    },
+	"fontSize": {
+		"value": "16",
+		"type": "sizing",
+		"description": "Default fontSize for the browser, may be overriden by user preferences"
+	  },
+	  "baseline": {
+		"value": "{base.fontSize} / 2",
+		"type": "sizing",
+		"description": "Baseline unit used for the 8pt sizing grid"
+	  }
+  },
+  "size": {
+    "25": {
+      "value": "{base.baseline} * 0.25",
+      "type": "sizing",
+      "description": "2px / 0.125rem"
+    },
+    "50": {
+      "value": "{base.baseline} * 0.50",
+      "type": "sizing",
+      "description": "4px / 0.25rem"
+    },
+    "75": {
+      "value": "{base.baseline} * 0.75",
+      "type": "sizing",
+      "description": "6px / 0.375rem"
+    },
+    "100": {
+      "value": "{base.baseline} * 1.00",
+      "type": "sizing",
+      "description": "8px / 0.5rem"
+    },
+    "125": {
+      "value": "{base.baseline} * 1.25",
+      "type": "sizing",
+      "description": "10px / 0.625rem"
+    },
+    "150": {
+      "value": "{base.baseline} * 1.50",
+      "type": "sizing",
+      "description": "12px / 0.75rem"
+    },
+    "175": {
+      "value": "{base.baseline} * 1.75",
+      "type": "sizing",
+      "description": "14px / 0.875rem"
+    },
+    "200": {
+      "value": "{base.baseline} * 2.00",
+      "type": "sizing",
+      "description": "16px / 1rem"
+    },
+    "225": {
+      "value": "{base.baseline} * 2.25",
+      "type": "sizing",
+      "description": "18px / 1.125rem"
+    },
+    "250": {
+      "value": "{base.baseline} * 2.50",
+      "type": "sizing",
+      "description": "20px / 1.25rem"
+    },
+    "300": {
+      "value": "{base.baseline} * 3.00",
+      "type": "sizing",
+      "description": "24px / 1.5rem"
+    },
+    "350": {
+      "value": "{base.baseline} * 3.50",
+      "type": "sizing",
+      "description": "28px / 1.75rem"
+    },
+    "400": {
+      "value": "{base.baseline} * 4.00",
+      "type": "sizing",
+      "description": "32px / 2rem"
+    },
+    "450": {
+      "value": "{base.baseline} * 4.50",
+      "type": "sizing",
+      "description": "36px / 2.25rem"
+    },
+    "500": {
+      "value": "{base.baseline} * 5.00",
+      "type": "sizing",
+      "description": "40px / 2.5rem"
+    },
+    "600": {
+      "value": "{base.baseline} * 6.00",
+      "type": "sizing",
+      "description": "48px / 3rem"
+    },
+    "700": {
+      "value": "{base.baseline} * 7.00",
+      "type": "sizing",
+      "description": "56px / 3.5rem"
+    },
+    "800": {
+      "value": "{base.baseline} * 8.00",
+      "type": "sizing",
+      "description": "64px / 4rem"
+    },
+    "900": {
+      "value": "{base.baseline} * 9.00",
+      "type": "sizing",
+      "description": "72px / 4.5rem"
+    },
+    "1100": {
+      "value": "{base.baseline} * 11.00",
+      "type": "sizing",
+      "description": "88px / 5.5rem"
+    },
+    "1200": {
+      "value": "{base.baseline} * 12.00",
+      "type": "sizing",
+      "description": "96px / 6rem"
+    },
+    "1300": {
+      "value": "{base.baseline} * 13.00",
+      "type": "sizing",
+      "description": "104px / 6.5rem"
+    },
+    "1400": {
+      "value": "{base.baseline} * 14.00",
+      "type": "sizing",
+      "description": "112px / 7rem"
     }
   },
   "font-size": {
     "25": {
       "value": "0.625rem",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "50": {
       "value": "{font-size.25} + {typescale.size.default}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "75": {
       "value": "{font-size.50} + {typescale.size.default}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "100": {
       "value": "{font-size.75} + {typescale.size.default}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "125": {
       "value": "{font-size.100} + {typescale.size.default}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "150": {
       "value": "{font-size.125} + {typescale.size.default}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "200": {
       "value": "{font-size.150} + {typescale.size.heading}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "250": {
       "value": "{font-size.200} + {typescale.size.heading}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "300": {
       "value": "{font-size.250} + {typescale.size.heading}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "400": {
       "value": "{font-size.300} + {typescale.size.title}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "500": {
       "value": "{font-size.400} + {typescale.size.title}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "600": {
       "value": "{font-size.500} + {typescale.size.title}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "750": {
       "value": "{font-size.600} + {typescale.size.display}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "900": {
       "value": "{font-size.750} + {typescale.size.display}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "1050": {
       "value": "{font-size.900} + {typescale.size.display}",
-      "type": "fontSizes"
+      "type": "fontSizes",
+      "deprecated": true,
+      "deprecatedComment": "Use {size.1050} for consistent spacing and sizing"
     }
   },
   "line-height": {
     "50": {
       "value": "16",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "100": {
       "value": "20",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "150": {
       "value": "24",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "200": {
       "value": "28",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "250": {
       "value": "32",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "300": {
       "value": "36",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "350": {
       "value": "40",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "400": {
       "value": "48",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "500": {
       "value": "56",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "600": {
       "value": "64",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "750": {
       "value": "72",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "900": {
       "value": "88",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     },
     "1050": {
       "value": "104",
-      "type": "number"
+      "type": "number",
+      "deprecated": true,
+      "deprecatedComment": "Use system instead"
     }
   },
   "typescale": {
@@ -1822,27 +2007,34 @@
   "level": {
     "value": "2",
     "type": "number",
-    "description": "Used to calculate the skip level amount between levels in the type ramp, such as going from subtext to body, body to heading."
+    "description": "Used to calculate the skip level amount between levels in the type ramp, such as going from subtext to body, body to heading.",
+	"deprecated": true,
+	"deprecatedComment": "Use explicit size tokens instead of calculated type ramp values"
   },
   "shadow": {
+    "level": {
+      "value": "1",
+      "type": "number",
+      "description": "Shadow level multiplier for y offset and blur calculations"
+    },
     "1": {
       "100": {
         "y": {
-          "value": "1",
+          "value": "{shadow.level}",
           "type": "number"
         },
         "blur": {
-          "value": "4",
+          "value": "{size.50}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "2",
+          "value": "{shadow.level} * 2",
           "type": "number"
         },
         "blur": {
-          "value": "8",
+          "value": "{size.100}",
           "type": "number"
         }
       }
@@ -1850,21 +2042,21 @@
     "2": {
       "100": {
         "y": {
-          "value": "2",
+          "value": "{shadow.level} * 2",
           "type": "number"
         },
         "blur": {
-          "value": "8",
+          "value": "{size.100}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "4",
+          "value": "{shadow.level} * 4",
           "type": "number"
         },
         "blur": {
-          "value": "16",
+          "value": "{size.200}",
           "type": "number"
         }
       }
@@ -1872,21 +2064,21 @@
     "3": {
       "100": {
         "y": {
-          "value": "3",
+          "value": "{shadow.level} * 3",
           "type": "number"
         },
         "blur": {
-          "value": "12",
+          "value": "{size.150}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "6",
+          "value": "{shadow.level} * 6",
           "type": "number"
         },
         "blur": {
-          "value": "24",
+          "value": "{size.300}",
           "type": "number"
         }
       }
@@ -1894,21 +2086,21 @@
     "4": {
       "100": {
         "y": {
-          "value": "4",
+          "value": "{shadow.level} * 4",
           "type": "number"
         },
         "blur": {
-          "value": "16",
+          "value": "{size.200}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "8",
+          "value": "{shadow.level} * 8",
           "type": "number"
         },
         "blur": {
-          "value": "32",
+          "value": "{size.400}",
           "type": "number"
         }
       }
@@ -1916,21 +2108,21 @@
     "5": {
       "100": {
         "y": {
-          "value": "5",
+          "value": "{shadow.level} * 5",
           "type": "number"
         },
         "blur": {
-          "value": "20",
+          "value": "{size.250}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "10",
+          "value": "{shadow.level} * 10",
           "type": "number"
         },
         "blur": {
-          "value": "40",
+          "value": "{size.500}",
           "type": "number"
         }
       }
@@ -1938,21 +2130,21 @@
     "6": {
       "100": {
         "y": {
-          "value": "6",
+          "value": "{shadow.level} * 6",
           "type": "number"
         },
         "blur": {
-          "value": "24",
+          "value": "{size.300}",
           "type": "number"
         }
       },
       "200": {
         "y": {
-          "value": "12",
+          "value": "{shadow.level} * 12",
           "type": "number"
         },
         "blur": {
-          "value": "48",
+          "value": "{size.600}",
           "type": "number"
         }
       }

--- a/tokens/base.json
+++ b/tokens/base.json
@@ -1631,6 +1631,11 @@
 	  }
   },
   "size": {
+	"0": {
+      "value": "{base.baseline} * 0.00",
+      "type": "sizing",
+      "description": "0px / 0rem"
+    },
     "25": {
       "value": "{base.baseline} * 0.25",
       "type": "sizing",

--- a/tokens/sys/breakpoint.json
+++ b/tokens/sys/breakpoint.json
@@ -6,22 +6,22 @@
       "description": "Use to set a media query `min-width` below small."
     },
     "s": {
-      "value": "{base.unit} * 80",
+      "value": "{base.baseline} * 40",
       "type": "dimension",
       "description": "The `min-width` for mobile devices, such as phones and tablets."
     },
     "m": {
-      "value": "{base.unit} * 192",
+      "value": "{base.baseline} * 96",
       "type": "dimension",
       "description": "Medium screens, such as laptops."
     },
     "l": {
-      "value": "{base.unit} * 256",
+      "value": "{base.baseline} * 128",
       "type": "dimension",
       "description": "Large screens, such as desktops."
     },
     "xl": {
-      "value": "{base.unit} * 360",
+      "value": "{base.baseline} * 180",
       "type": "dimension",
       "description": "Used for extra large screens, such as wide monitors and TVs."
     }

--- a/tokens/sys/shape.json
+++ b/tokens/sys/shape.json
@@ -1,42 +1,68 @@
 {
   "shape": {
     "zero": {
-      "value": "0rem",
+      "value": "{size.0}",
       "type": "borderRadius",
-      "description": "This is the initial shape of every new element. Use this for backgrounds screens and fixed navigation containers such as headers, and side-panels."
+      "description": "Full-width and background containers. Fixed navigation containers such as headers, and side-panels."
+    },
+    "sm": {
+      "value": "{size.50}",
+      "type": "borderRadius",
+      "description": "Use this for subtle and smaller elements that don't contain complex information. Often high-density components. Checkbox, Pill"
+    },
+    "md": {
+      "value": "{size.100}",
+      "type": "borderRadius",
+      "description": "Components presenting info text, user input, user feedback. Inputs, Toasts, Snack bars, Tooltips, Error Alert Banner"
+    },
+    "lg": {
+      "value": "{size.200}",
+      "type": "borderRadius",
+      "description": "Core large containers, card containers and popups that house moderate amounts of content and/or data: Card, Menus"
+    },
+    "xl": {
+      "value": "{size.300}",
+      "type": "borderRadius",
+      "description": "Primarily used for elevated and simple parent containers with greater amounts of content and UI. Dialogs, Modals, Bottom Sheets"
+    },
+    "round": {
+      "value": "{size.75} * 100",
+      "type": "borderRadius",
+      "description": "Full rounding is reserved high-visibility components. This shape is intended to draw attention. Buttons, Badge, Status Indicator, Essential Inputs, Border Containers (Not Cards)"
     },
     "half": {
       "value": "{base.unit} * 0.5",
       "type": "borderRadius",
-      "description": "Use this for subtle and small components that don’t require to group complex information like Status Indicators, Checkboxes and Color Swatches."
+      "deprecated": true,
+      "description": "Use this for subtle and small components that don't require to group complex information like Status Indicators, Checkboxes and Color Swatches."
     },
     "x1": {
       "value": "{base.unit}",
-      "type": "borderRadius"
+      "type": "borderRadius",
+      "deprecated": true
     },
     "x1-half": {
       "value": "{base.unit} * 1.5",
-      "type": "borderRadius"
+      "type": "borderRadius",
+      "deprecated": true
     },
     "x2": {
       "value": "{base.unit} * 2",
       "type": "borderRadius",
+      "deprecated": true,
       "description": "Use this for all the containers and popups: All Cards, Modals, Tooltips and Toasts."
     },
     "x4": {
       "value": "{base.unit} * 4",
       "type": "borderRadius",
-      "description": "(Mobile) Primary containers that house a large amount of other elements and complex information\n"
+      "deprecated": true,
+      "description": "(Mobile) Primary containers that house a large amount of other elements and complex information"
     },
     "x6": {
       "value": "{base.unit} * 6",
       "type": "borderRadius",
+      "deprecated": true,
       "description": "(Mobile) Full width sheets that are temporary and modal views"
-    },
-    "round": {
-      "value": "{base.unit} * 250",
-      "type": "borderRadius",
-      "description": "Commonly used for our standard buttons and profile avatars: All Primary, Secondary Buttons, Radio Buttons and Notification Badges."
     }
   }
 }

--- a/tokens/sys/type.json
+++ b/tokens/sys/type.json
@@ -16,57 +16,57 @@
   "font-size": {
     "subtext": {
       "small": {
-        "value": "{font-size.25}",
+        "value": "{size.125}",
         "type": "sizing"
       },
       "medium": {
-        "value": "{font-size.50}",
+        "value": "{size.150}",
         "type": "sizing"
       },
       "large": {
-        "value": "{font-size.75}",
+        "value": "{size.175}",
         "type": "sizing"
       }
     },
     "body": {
       "small": {
-        "value": "{font-size.100}",
+        "value": "{size.200}",
         "type": "sizing"
       },
       "medium": {
-        "value": "{font-size.125}",
+        "value": "{size.225}",
         "type": "sizing"
       },
       "large": {
-        "value": "{font-size.150}",
+        "value": "{size.250}",
         "type": "sizing"
       }
     },
     "heading": {
       "small": {
-        "value": "{font-size.200}",
+        "value": "{size.300}",
         "type": "sizing"
       },
       "medium": {
-        "value": "{font-size.250}",
+        "value": "{size.350}",
         "type": "sizing"
       },
       "large": {
-        "value": "{font-size.300}",
+        "value": "{size.400}",
         "type": "sizing"
       }
     },
     "title": {
       "small": {
-        "value": "{font-size.400}",
+        "value": "{size.500}",
         "type": "sizing"
       },
       "medium": {
-        "value": "{font-size.500}",
+        "value": "{size.600}",
         "type": "sizing"
       },
       "large": {
-        "value": "{font-size.600}",
+        "value": "{size.700}",
         "type": "sizing"
       }
     }
@@ -74,57 +74,79 @@
   "line-height": {
     "subtext": {
       "small": {
-        "value": "{line-height.50}",
+        "value": "{size.200}",
         "type": "number"
       },
       "medium": {
-        "value": "{line-height.50}",
+        "value": "{size.200}",
         "type": "number"
       },
       "large": {
-        "value": "{line-height.100}",
+        "value": "{size.250}",
         "type": "number"
       }
     },
     "body": {
       "small": {
-        "value": "{line-height.150}",
+        "value": "{size.300}",
         "type": "number"
       },
       "medium": {
-        "value": "{line-height.200}",
+        "value": "{size.350}",
         "type": "number"
       },
       "large": {
-        "value": "{line-height.200}",
+        "value": "{size.350}",
         "type": "number"
       }
     },
     "heading": {
       "small": {
-        "value": "{line-height.250}",
+        "value": "{size.400}",
         "type": "number"
       },
       "medium": {
-        "value": "{line-height.300}",
+        "value": "{size.450}",
         "type": "number"
       },
       "large": {
-        "value": "{line-height.350}",
+        "value": "{size.500}",
         "type": "number"
       }
     },
     "title": {
       "small": {
-        "value": "{line-height.400}",
+        "value": "{size.600}",
         "type": "number"
       },
       "medium": {
-        "value": "{line-height.500}",
+        "value": "{size.700}",
         "type": "number"
       },
       "large": {
-        "value": "{line-height.600}",
+        "value": "{size.800}",
+        "type": "number"
+      }
+    }
+  },
+  "letter-spacing": {
+    "subtext": {
+      "small": {
+        "value": "{letter-spacing.50}",
+        "type": "number"
+      },
+      "medium": {
+        "value": "{letter-spacing.100}",
+        "type": "number"
+      },
+      "large": {
+        "value": "{letter-spacing.150}",
+        "type": "number"
+      }
+    },
+    "body": {
+      "small": {
+        "value": "{letter-spacing.200}",
         "type": "number"
       }
     }
@@ -155,7 +177,7 @@
           "fontWeight": "{font-weight.normal}",
           "lineHeight": "{line-height.subtext.small}",
           "fontSize": "{font-size.subtext.small}",
-          "letterSpacing": "{letter-spacing.50}"
+          "letterSpacing": "{letter-spacing.subtext.small}"
         },
         "type": "typography"
       },
@@ -165,7 +187,7 @@
           "fontWeight": "{font-weight.normal}",
           "lineHeight": "{line-height.subtext.medium}",
           "fontSize": "{font-size.subtext.medium}",
-          "letterSpacing": "{letter-spacing.100}"
+          "letterSpacing": "{letter-spacing.subtext.medium}"
         },
         "type": "typography"
       },
@@ -175,7 +197,7 @@
           "fontWeight": "{font-weight.normal}",
           "lineHeight": "{line-height.subtext.large}",
           "fontSize": "{font-size.subtext.large}",
-          "letterSpacing": "{letter-spacing.150}"
+          "letterSpacing": "{letter-spacing.subtext.large}"
         },
         "type": "typography"
       }
@@ -187,7 +209,7 @@
           "fontWeight": "{font-weight.normal}",
           "lineHeight": "{line-height.body.small}",
           "fontSize": "{font-size.body.small}",
-          "letterSpacing": "{letter-spacing.200}"
+          "letterSpacing": "{letter-spacing.body.small}"
         },
         "type": "typography"
       },
@@ -273,547 +295,488 @@
     "Subtext": {
       "Subtext S - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}",
+          "letterSpacing": "{letter-spacing.subtext.small}"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}",
+          "letterSpacing": "{letter-spacing.subtext.small}"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}",
+          "letterSpacing": "{letter-spacing.subtext.small}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}",
+          "letterSpacing": "{letter-spacing.subtext.small}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}",
+          "letterSpacing": "{letter-spacing.subtext.small}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Mono - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Mono - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext S Mono - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.25}",
-          "letterSpacing": "{letter-spacing.50}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.small}"
         },
-        "type": "typography",
-        "description": "Subtext Small (10px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}",
+          "letterSpacing": "{letter-spacing.subtext.medium}"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}",
+          "letterSpacing": "{letter-spacing.subtext.medium}"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}",
+          "letterSpacing": "{letter-spacing.subtext.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}",
+          "letterSpacing": "{letter-spacing.subtext.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}",
+          "letterSpacing": "{letter-spacing.subtext.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Mono - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Mono - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext M Mono - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.50}",
-          "fontSize": "{font-size.50}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.small}",
+          "fontSize": "{font-size.subtext.medium}"
         },
-        "type": "typography",
-        "description": "Subtext Medium (12px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}",
+          "letterSpacing": "{letter-spacing.subtext.large}"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}",
+          "letterSpacing": "{letter-spacing.subtext.large}"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}",
+          "letterSpacing": "{letter-spacing.subtext.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}",
+          "letterSpacing": "{letter-spacing.subtext.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}",
+          "letterSpacing": "{letter-spacing.subtext.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Mono - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Mono - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Subtext L Mono - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.100}",
-          "fontSize": "{font-size.75}",
-          "letterSpacing": "{letter-spacing.150}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.subtext.medium}",
+          "fontSize": "{font-size.subtext.large}"
         },
-        "type": "typography",
-        "description": "Subtext Large (14px) - (500) Medium\n\n🧩Advised Use:\nComplex data\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       }
     },
     "Body": {
       "Body S - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.200}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}",
+          "letterSpacing": "{letter-spacing.body.small}"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body S - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.200}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}",
+          "letterSpacing": "{letter-spacing.body.small}"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body S Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.100}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}",
+          "letterSpacing": "{letter-spacing.subtext.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body S Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.200}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}",
+          "letterSpacing": "{letter-spacing.body.small}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body S Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.200}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}",
+          "letterSpacing": "{letter-spacing.body.small}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body S Mono - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.100}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.150}",
-          "fontSize": "{font-size.100}",
-          "letterSpacing": "{letter-spacing.100}"
+          "fontFamily": "{font-family.mono}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.body.small}",
+          "fontSize": "{font-size.body.small}"
         },
-        "type": "typography",
-        "description": "Body Small (16px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body M - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.125}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.medium}"
         },
-        "type": "typography",
-        "description": "Body Medium (18px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body M - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.125}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.medium}"
         },
-        "type": "typography",
-        "description": "Body Medium (18px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body M Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.125}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Medium (18px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body M Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.125}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Medium (18px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body M Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.125}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.medium}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Medium (18px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body L - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.150}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.large}"
         },
-        "type": "typography",
-        "description": "Body Large (20px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body L - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.150}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.large}"
         },
-        "type": "typography",
-        "description": "Body Large (20px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body L Link - (400) Regular": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.400}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.normal}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Large (20px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body L Link - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Large (20px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Body L Link - (700) Bold": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.700}",
-          "lineHeight": "{line-height.200}",
-          "fontSize": "{font-size.150}",
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.bold}",
+          "lineHeight": "{line-height.body.medium}",
+          "fontSize": "{font-size.body.large}",
           "textDecoration": "underline"
         },
-        "type": "typography",
-        "description": "Body Large (20px) - (500) Medium\n\n🧩Advised Use:\nParagraphs\n\n🖍Main Color:\nBlack Pepper 300\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       }
     },
     "Heading": {
       "Heading S - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.250}",
-          "fontSize": "{font-size.200}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.heading.small}",
+          "fontSize": "{font-size.heading.small}"
         },
-        "type": "typography",
-        "description": "Heading Small (24px) - (500) Medium\n\n🧩Advised Use:\nHeadings and Subheadings\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Heading M - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.300}",
-          "fontSize": "{font-size.250}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.heading.medium}",
+          "fontSize": "{font-size.heading.medium}"
         },
-        "type": "typography",
-        "description": "Heading Medium (28px) - (500) Medium\n\n🧩Advised Use:\nHeadings and Subheadings\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Heading L - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.350}",
-          "fontSize": "{font-size.300}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.heading.large}",
+          "fontSize": "{font-size.heading.large}"
         },
-        "type": "typography",
-        "description": "Heading Large (32px) - (500) Medium\n\n🧩Advised Use:\nHeadings and Subheadings\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       }
     },
     "Title": {
       "Title S - (300) Light": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.300}",
-          "lineHeight": "{line-height.400}",
-          "fontSize": "{font-size.400}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.light}",
+          "lineHeight": "{line-height.title.small}",
+          "fontSize": "{font-size.title.small}"
         },
-        "type": "typography",
-        "description": "Title Small (40px) - (300) Light\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Title S - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.400}",
-          "fontSize": "{font-size.400}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.title.small}",
+          "fontSize": "{font-size.title.small}"
         },
-        "type": "typography",
-        "description": "Title Small (40px) - (500) Medium\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Title M - (300) Light": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.300}",
-          "fontSize": "{font-size.500}",
-          "lineHeight": "{line-height.500}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.light}",
+          "fontSize": "{font-size.title.medium}",
+          "lineHeight": "{line-height.title.medium}"
         },
-        "type": "typography",
-        "description": "Title Medium (48px) - (300) Light\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Title M - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.500}",
-          "fontSize": "{font-size.500}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.title.medium}",
+          "fontSize": "{font-size.title.medium}"
         },
-        "type": "typography",
-        "description": "Title Medium (48px) - (500) Medium\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Title L - (300) Light": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.300}",
-          "lineHeight": "{line-height.600}",
-          "fontSize": "{font-size.600}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.light}",
+          "lineHeight": "{line-height.title.large}",
+          "fontSize": "{font-size.title.large}"
         },
-        "type": "typography",
-        "description": "Title Large (56px) - (300) Light\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       },
       "Title L - (500) Medium": {
         "value": {
-          "fontFamily": "{font-family.50}",
-          "fontWeight": "{font-weight.500}",
-          "lineHeight": "{line-height.600}",
-          "fontSize": "{font-size.600}"
+          "fontFamily": "{font-family.default}",
+          "fontWeight": "{font-weight.medium}",
+          "lineHeight": "{line-height.title.large}",
+          "fontSize": "{font-size.title.large}"
         },
-        "type": "typography",
-        "description": "Title Small (56px) - (500) Medium\n\n🧩Advised Use:\nTitles\n\n🖍Main Color:\nBlack Pepper 400\n\n✚ More Colors:\nSee Type Color Swatches"
+        "type": "typography"
       }
     }
   }


### PR DESCRIPTION
- Added new size tokens to base layer. Updated dependencies to reference size as needed.
- Shadow base blur values updated to use base size tokens. 2nd Y offset updated to be based off the 1st Y offset
- Added deprecated flag to base font-size, line-height and type-scale as they are no longer used in system. 
- Type compound tokens alias system font-size, line-height, etc.
- Shape tokens updated to use t-shirt sizing and alias base size tokens. Old shape tokens deprecated.
- Breakpoint tokens updated to reference base.baseline instead of base.unit (deprecated)
- Space tokens kept the same for now, they will be updated in another PR
