### PR TITLE
fix: Fix visual report

### DIFF
--- a/utils/visual-report.js
+++ b/utils/visual-report.js
@@ -21,9 +21,10 @@ const getDirectoryFiles = directory => {
       return false;
     }
 
-    const isBase = file.endsWith('base.json');
+    const isBase = file.endsWith('/base');
     const isBrand = file.endsWith('canvas.json');
     const isColor = file.includes('sys/color');
+
     const isSystem =
       file.includes('sys/') && !file.includes('sys/brand') && !file.includes('sys/color');
 


### PR DESCRIPTION
## Issue

<!-- Provide an issue # if one exists -->

## Overview

Fix visual report build if base tokens are organized in folder.

## Checks

- [ ] Overview Added
- [ ] Deprecated tokens placed in `deprecated` folder
- [ ] Deprecated tokens file structure is the same as main.
- [ ] Main tokens file doesn't have deprecated tokens.
- [ ] Math values have spaces around math sign.

## Thank You Gif

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer: -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
