### PR TITLE
fix: Add value to deprecated dragon fruit to build correctly

### DIFF
--- a/tokens/deprecated/base.json
+++ b/tokens/deprecated/base.json
@@ -1181,42 +1181,42 @@
     "palette": {
       "dragon-fruit": {
         "100": {
-          "value": "",
+          "value": "#fbf5ff",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit100 with {base.palette.purple.25}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
           "fallback": "{base.palette.purple.25}"
         },
         "200": {
-          "value": "",
+          "value": "#f1d5ff",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit200 with {base.palette.purple.100}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
           "fallback": "{base.palette.purple.100}"
         },
         "300": {
-          "value": "",
+          "value": "#736bff",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit300 with {base.palette.indigo.500}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
           "fallback": "{base.palette.indigo.500}"
         },
         "400": {
-          "value": "",
+          "value": "#5f4ae6",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit400 with {base.palette.indigo.600}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
           "fallback": "{base.palette.indigo.600}"
         },
         "500": {
-          "value": "",
+          "value": "#4e3ec2",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit500 with {base.palette.indigo.700}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
           "fallback": "{base.palette.indigo.700}"
         },
         "600": {
-          "value": "",
+          "value": "#272077",
           "type": "color",
           "deprecated": true,
           "deprecatedComment": "replace dragon-fruit600 with {base.palette.indigo.900}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",


### PR DESCRIPTION
Our build system skips over values that are empty. Adding a hex value will correctly choose the fallback value.