### PR TITLE
fix: Update deprecated color token comments

### DIFF
--- a/tokens/deprecated/base/palette.json
+++ b/tokens/deprecated/base/palette.json
@@ -5,14 +5,14 @@
         "value": "#ffefee",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cinnamon100 with {palette.red.50}. Prefer to replace with `sys.color.bg.critical.softer` if used as a background color.",
+        "deprecatedComment": "replace cinnamon100 with {palette.red.50}. Prefer to replace with `system.color.bg.critical.softer` if used as a background color.",
         "fallback": "{palette.red.50}"
       },
       "200": {
         "value": "#FCC9C5",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cinnamon200 with {palette.red.100}. Prefer to replace with `sys.color.bg.critical.soft` if used as a background color.",
+        "deprecatedComment": "replace cinnamon200 with {palette.red.100}. Prefer to replace with `system.color.bg.critical.soft` if used as a background color.",
         "fallback": "{palette.red.100}"
       },
       "300": {
@@ -26,21 +26,21 @@
         "value": "#ff5347",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cinnamon400 with {palette.red.400}. Prefer to replace with `sys.color.fg.critical.soft` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace cinnamon400 with {palette.red.400}. Prefer to replace with `system.color.fg.critical.soft` if used as a foreground (text/icon) color.",
         "fallback": "{palette.red.400}"
       },
       "500": {
         "value": "#de2e21",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cinnamon500 with {palette.red.600}. Prefer to replace with `sys.color.bg.critical.default` if used as a background color, or `sys.color.fg.critical.default` if used as a foreground (text/icon) color, or `sys.color.border.critical.default` if used as a border color.",
+        "deprecatedComment": "replace cinnamon500 with {palette.red.600}. Prefer to replace with `system.color.bg.critical.default` if used as a background color, or `system.color.fg.critical.default` if used as a foreground (text/icon) color, or `system.color.border.critical.default` if used as a border color.",
         "fallback": "{palette.red.600}"
       },
       "600": {
         "value": "#a31b12",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cinnamon600 with {palette.red.700}. Prefer to replace with `sys.color.bg.critical.strong` if used as a background color, or `sys.color.fg.critical.strong` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace cinnamon600 with {palette.red.700}. Prefer to replace with `system.color.bg.critical.strong` if used as a background color, or `system.color.fg.critical.strong` if used as a foreground (text/icon) color.",
         "fallback": "{palette.red.700}"
       }
     },
@@ -137,42 +137,42 @@
         "value": "#ffeed9",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe100 with {palette.amber.50}. Prefer to replace with `sys.color.bg.caution.softer` if used as a background color.",
+        "deprecatedComment": "replace cantaloupe100 with {palette.amber.50}. Prefer to replace with `system.color.bg.caution.softer` if used as a background color.",
         "fallback": "{palette.amber.50}"
       },
       "200": {
         "value": "#fcd49f",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe200 with {palette.amber.200}. Prefer to replace with `sys.color.fg.caution.softer` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace cantaloupe200 with {palette.amber.200}. Prefer to replace with `system.color.fg.caution.softer` if used as a foreground (text/icon) color.",
         "fallback": "{palette.amber.200}"
       },
       "300": {
         "value": "#ffbc63",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe300 with {palette.amber.300}. Prefer to replace with `sys.color.bg.caution.soft` if used as a background color.",
+        "deprecatedComment": "replace cantaloupe300 with {palette.amber.300}. Prefer to replace with `system.color.bg.caution.soft` if used as a background color.",
         "fallback": "{palette.amber.300}"
       },
       "400": {
         "value": "#ffa126",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe400 with {palette.amber.400}. Prefer to replace with `sys.color.bg.caution.default` if used as a background color, or `sys.color.border.caution.default` if used as a border color.",
+        "deprecatedComment": "replace cantaloupe400 with {palette.amber.400}. Prefer to replace with `system.color.bg.caution.default` if used as a background color, or `system.color.border.caution.default` if used as a border color.",
         "fallback": "{palette.amber.400}"
       },
       "500": {
         "value": "#f38b00",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe500 with {palette.amber.500}. Prefer to replace with `sys.color.bg.caution.strong` if used as a background color.",
+        "deprecatedComment": "replace cantaloupe500 with {palette.amber.500}. Prefer to replace with `system.color.bg.caution.strong` if used as a background color.",
         "fallback": "{palette.amber.500}"
       },
       "600": {
         "value": "#c06c00",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace cantaloupe600 with {palette.amber.600}. Prefer to replace with `sys.color.bg.caution.stronger` if used as a background color, or with `sys.color.border.caution.strong` if used as a border color.",
+        "deprecatedComment": "replace cantaloupe600 with {palette.amber.600}. Prefer to replace with `system.color.bg.caution.stronger` if used as a background color, or with `system.color.border.caution.strong` if used as a border color.",
         "fallback": "{palette.amber.600}"
       }
     },
@@ -313,42 +313,42 @@
         "value": "#ebfff0",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple100 with {palette.green.50}. Prefer to replace with `sys.color.bg.positive.softer` if used as a background color.",
+        "deprecatedComment": "replace green-apple100 with {palette.green.50}. Prefer to replace with `system.color.bg.positive.softer` if used as a background color.",
         "fallback": "{palette.green.50}"
       },
       "200": {
         "value": "#acf5be",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple200 with {palette.green.100}. Prefer to replace with `sys.color.bg.positive.soft` if used as a background color.",
+        "deprecatedComment": "replace green-apple200 with {palette.green.100}. Prefer to replace with `system.color.bg.positive.soft` if used as a background color.",
         "fallback": "{palette.green.100}"
       },
       "300": {
         "value": "#5fe380",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple300 with {palette.green.200}. Prefer to replace with `sys.color.fg.positive.soft` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace green-apple300 with {palette.green.200}. Prefer to replace with `system.color.fg.positive.soft` if used as a foreground (text/icon) color.",
         "fallback": "{palette.green.200}"
       },
       "400": {
         "value": "#43c463",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple400 with {palette.green.600}. Prefer to replace with `sys.color.bg.positive.default` if used as a background color, or `sys.color.fg.positive.default` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace green-apple400 with {palette.green.600}. Prefer to replace with `system.color.bg.positive.default` if used as a background color, or `system.color.fg.positive.default` if used as a foreground (text/icon) color.",
         "fallback": "{palette.green.600}"
       },
       "500": {
         "value": "#319c4c",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple500 with {palette.green.700}. Prefer to replace with `sys.color.bg.positive.strong` if used as a background color, or `sys.color.fg.positive.strong` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace green-apple500 with {palette.green.700}. Prefer to replace with `system.color.bg.positive.strong` if used as a background color, or `system.color.fg.positive.strong` if used as a foreground (text/icon) color.",
         "fallback": "{palette.green.700}"
       },
       "600": {
         "value": "#217a37",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace green-apple600 with {palette.green.800}. Prefer to replace with `sys.color.bg.positive.stronger` if used as a background color, or `sys.color.text.positive.stronger` if used as a text color.",
+        "deprecatedComment": "replace green-apple600 with {palette.green.800}. Prefer to replace with `system.color.bg.positive.stronger` if used as a background color, or `system.color.text.positive.stronger` if used as a text color.",
         "fallback": "{palette.green.800}"
       }
     },
@@ -496,35 +496,35 @@
         "value": "#A6D2FF",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace blueberry200 with {palette.blue.100}. Prefer to replace with `sys.color.bg.primary.soft` if used as a background color.",
+        "deprecatedComment": "replace blueberry200 with {palette.blue.100}. Prefer to replace with `system.color.bg.primary.soft` if used as a background color.",
         "fallback": "{palette.blue.100}"
       },
       "300": {
         "value": "#40A0FF",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace blueberry300 with {palette.blue.400}. Prefer to replace with `sys.color.bg.primary.default` if used as a background color, or `sys.color.fg.primary.soft` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace blueberry300 with {palette.blue.400}. Prefer to replace with `system.color.bg.primary.default` if used as a background color, or `system.color.fg.primary.soft` if used as a foreground (text/icon) color.",
         "fallback": "{palette.blue.400}"
       },
       "400": {
         "value": "#0875E1",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace blueberry400 with {palette.blue.600}. Prefer to replace with `sys.color.bg.primary.default` if used as a background color, or `sys.color.fg.primary.default` if used as a foreground (text/icon) color, or `sys.color.border.primary.default` if used as a border color.",
+        "deprecatedComment": "replace blueberry400 with {palette.blue.600}. Prefer to replace with `system.color.bg.primary.default` if used as a background color, or `system.color.fg.primary.default` if used as a foreground (text/icon) color, or `system.color.border.primary.default` if used as a border color.",
         "fallback": "{palette.blue.600}"
       },
       "500": {
         "value": "#005cb9",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace blueberry500 with {palette.blue.700}. Prefer to replace with `sys.color.bg.primary.strong` if used as a background color, or `sys.color.fg.primary.strong` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace blueberry500 with {palette.blue.700}. Prefer to replace with `system.color.bg.primary.strong` if used as a background color, or `system.color.fg.primary.strong` if used as a foreground (text/icon) color.",
         "fallback": "{palette.blue.700}"
       },
       "600": {
         "value": "#004387",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace blueberry600 with {palette.blue.800}. Prefer to replace with `sys.color.bg.primary.stronger` if used as a background color, or `sys.color.text.primary.stronger` if used as a text color.",
+        "deprecatedComment": "replace blueberry600 with {palette.blue.800}. Prefer to replace with `system.color.bg.primary.stronger` if used as a background color, or `system.color.text.primary.stronger` if used as a text color.",
         "fallback": "{palette.blue.800}"
       }
     },
@@ -929,35 +929,35 @@
         "value": "#A1AAB3",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace licorice100 with {palette.slate.400}. Prefer to replace with `sys.color.bg.muted.softer` if used as a background color, or `sys.color.fg.disabled` if used as a foreground (text/icon) color, or `sys.color.border.input.disabled` if used as a border color.",
+        "deprecatedComment": "replace licorice100 with {palette.slate.400}. Prefer to replace with `system.color.bg.muted.softer` if used as a background color, or `system.color.fg.disabled` if used as a foreground (text/icon) color, or `system.color.border.input.disabled` if used as a border color.",
         "fallback": "{palette.slate.400}"
       },
       "200": {
         "value": "#7b858f",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace licorice200 with {palette.slate.500}. Prefer to replace with `sys.color.bg.muted.soft` if used as a background color, or `sys.color.fg.muted.soft` if used as a foreground (text/icon) color, or `sys.color.border.input.default` if used as a border color.",
+        "deprecatedComment": "replace licorice200 with {palette.slate.500}. Prefer to replace with `system.color.bg.muted.soft` if used as a background color, or `system.color.fg.muted.soft` if used as a foreground (text/icon) color, or `system.color.border.input.default` if used as a border color.",
         "fallback": "{palette.slate.500}"
       },
       "300": {
         "value": "#5E6A75",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace licorice300 with {palette.slate.600}. Prefer to replace with `sys.color.bg.muted.default` if used as a background color, or `sys.color.fg.muted.default` if used as a foreground (text/icon) color, or `sys.color.text.hint` if used as a text hint color.",
+        "deprecatedComment": "replace licorice300 with {palette.slate.600}. Prefer to replace with `system.color.bg.muted.default` if used as a background color, or `system.color.fg.muted.default` if used as a foreground (text/icon) color, or `system.color.text.hint` if used as a text hint color.",
         "fallback": "{palette.slate.600}"
       },
       "400": {
         "value": "#4a5561",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace licorice400 with {palette.slate.700}. Prefer to replace with `sys.color.fg.muted.strong` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace licorice400 with {palette.slate.700}. Prefer to replace with `system.color.fg.muted.strong` if used as a foreground (text/icon) color.",
         "fallback": "{palette.slate.700}"
       },
       "500": {
         "value": "#333d47",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace licorice500 with {palette.slate.800}. Prefer to replace with `sys.color.bg.muted.strong` if used as a background color, or `sys.color.fg.muted.stronger` if used as a foreground (text/icon) color, or `sys.color.border.input.strong` if used as a border color.",
+        "deprecatedComment": "replace licorice500 with {palette.slate.800}. Prefer to replace with `system.color.bg.muted.strong` if used as a background color, or `system.color.fg.muted.stronger` if used as a foreground (text/icon) color, or `system.color.border.input.strong` if used as a border color.",
         "fallback": "{palette.slate.800}"
       },
       "600": {
@@ -973,35 +973,35 @@
         "value": "#f6f7f8",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace soap100 with {palette.slate.25}. Prefer to replace with `sys.color.bg.alt.softer` if used as a background color.",
+        "deprecatedComment": "replace soap100 with {palette.slate.25}. Prefer to replace with `system.color.bg.alt.softer` if used as a background color.",
         "fallback": "{palette.slate.25}"
       },
       "200": {
         "value": "#F0F1F2",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace soap200 with {palette.slate.50}. Prefer to replace with `sys.color.bg.alt.soft` if used as a background color.",
+        "deprecatedComment": "replace soap200 with {palette.slate.50}. Prefer to replace with `system.color.bg.alt.soft` if used as a background color.",
         "fallback": "{palette.slate.50}"
       },
       "300": {
         "value": "#e8ebed",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace soap300 with {palette.slate.100}. Prefer to replace with `sys.color.bg.alt.default` if used as a background color, or `sys.color.border.input.inverse` if used as a border color.",
+        "deprecatedComment": "replace soap300 with {palette.slate.100}. Prefer to replace with `system.color.bg.alt.default` if used as a background color, or `system.color.border.input.inverse` if used as a border color.",
         "fallback": "{palette.slate.100}"
       },
       "400": {
         "value": "#DFE2E6",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace soap400 with {palette.slate.200}. Prefer to replace with `sys.color.bg.alt.strong` if used as a background color, or `sys.color.border.divider` if used as a border color.",
+        "deprecatedComment": "replace soap400 with {palette.slate.200}. Prefer to replace with `system.color.bg.alt.strong` if used as a background color, or `system.color.border.divider` if used as a border color.",
         "fallback": "{palette.slate.200}"
       },
       "500": {
         "value": "#ced3d9",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace soap500 with {palette.slate.300}. Prefer to replace with `sys.color.bg.alt.stronger` if used as a background color, or `sys.color.border.container` if used as a border color.",
+        "deprecatedComment": "replace soap500 with {palette.slate.300}. Prefer to replace with `system.color.bg.alt.stronger` if used as a background color, or `system.color.border.container` if used as a border color.",
         "fallback": "{palette.slate.300}"
       },
       "600": {
@@ -1017,7 +1017,7 @@
         "value": "#ffffff",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace french-vanilla100 with {palette.neutral.0}. Prefer to replace with `sys.color.bg.default` if used as a background color, or `sys.color.fg.default` if used as a foreground (text/icon) color, or `sys.color.border.default` if used as a border color.",
+        "deprecatedComment": "replace french-vanilla100 with {palette.neutral.0}. Prefer to replace with `system.color.bg.default` if used as a background color, or `system.color.fg.default` if used as a foreground (text/icon) color, or `system.color.border.default` if used as a border color.",
         "fallback": "{palette.neutral.0}"
       },
       "200": {
@@ -1075,21 +1075,21 @@
         "value": "#494949",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace black-pepper300 with {palette.neutral.800}. Prefer to replace with `sys.color.fg.default` if used as a foreground (text/icon) color.",
+        "deprecatedComment": "replace black-pepper300 with {palette.neutral.800}. Prefer to replace with `system.color.fg.default` if used as a foreground (text/icon) color.",
         "fallback": "{palette.neutral.800}"
       },
       "400": {
         "value": "#333333",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace black-pepper400 with {palette.neutral.900}. Prefer to replace with `sys.color.bg.contrast.default` if used as a contrast background color, or `sys.color.fg.strong` if used as a foreground (text/icon) color, or `sys.color.border.contrast.default` if used as a border color.",
+        "deprecatedComment": "replace black-pepper400 with {palette.neutral.900}. Prefer to replace with `system.color.bg.contrast.default` if used as a contrast background color, or `system.color.fg.strong` if used as a foreground (text/icon) color, or `system.color.border.contrast.default` if used as a border color.",
         "fallback": "{palette.neutral.900}"
       },
       "500": {
         "value": "#1e1e1e",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace black-pepper500 with {palette.neutral.950}. Prefer to replace with `sys.color.bg.contrast.strong` if used as a contrast background color, or `sys.color.fg.stronger` if used as a foreground (text/icon) color, or `sys.color.border.contrast.strong` if used as a border color.",
+        "deprecatedComment": "replace black-pepper500 with {palette.neutral.950}. Prefer to replace with `system.color.bg.contrast.strong` if used as a contrast background color, or `system.color.fg.stronger` if used as a foreground (text/icon) color, or `system.color.border.contrast.strong` if used as a border color.",
         "fallback": "{palette.neutral.950}"
       },
       "600": {
@@ -1184,42 +1184,42 @@
           "value": "#fbf5ff",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit100 with {palette.purple.25}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit100 with {palette.purple.25}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.purple.25}"
         },
         "200": {
           "value": "#f1d5ff",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit200 with {palette.purple.100}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit200 with {palette.purple.100}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.purple.100}"
         },
         "300": {
           "value": "#736bff",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit300 with {palette.indigo.500}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit300 with {palette.indigo.500}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.indigo.500}"
         },
         "400": {
           "value": "#5f4ae6",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit400 with {palette.indigo.600}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit400 with {palette.indigo.600}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.indigo.600}"
         },
         "500": {
           "value": "#4e3ec2",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit500 with {palette.indigo.700}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit500 with {palette.indigo.700}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.indigo.700}"
         },
         "600": {
           "value": "#272077",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace dragon-fruit600 with {palette.indigo.900}. Prefer to replace it with ai system tokens: `sys.color.bg.ai.*`, `sys.color.border.ai` or `sys.color.text.ai`.",
+          "deprecatedComment": "replace dragon-fruit600 with {palette.indigo.900}. Prefer to replace it with ai system tokens: `system.color.bg.ai.*`, `system.color.border.ai` or `system.color.text.ai`.",
           "fallback": "{palette.indigo.900}"
         }
       }

--- a/tokens/deprecated/sys/brand/canvas.json
+++ b/tokens/deprecated/sys/brand/canvas.json
@@ -33,7 +33,7 @@
         "value": "{sys.color.fg.inverse}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace primary.accent with {sys.color.fg.inverse}",
+        "deprecatedComment": "replace primary.accent with {system.color.fg.inverse}",
         "fallback": "{sys.color.fg.inverse}"
       },
       "lighter": {
@@ -84,7 +84,7 @@
         "value": "{sys.color.fg.inverse}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace error.accent with {sys.color.fg.inverse}",
+        "deprecatedComment": "replace error.accent with {system.color.fg.inverse}",
         "fallback": "{sys.color.fg.inverse}"
       },
       "lighter": {
@@ -142,7 +142,7 @@
         "value": "{sys.color.fg.contrast.default}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace alert.darkest with {sys.color.fg.contrast.default}",
+        "deprecatedComment": "replace alert.darkest with {system.color.fg.contrast.default}",
         "fallback": "{sys.color.fg.contrast.default}"
       },
       "light": {
@@ -193,7 +193,7 @@
         "value": "{sys.color.fg.inverse}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace success.accent with {sys.color.fg.inverse}",
+        "deprecatedComment": "replace success.accent with {system.color.fg.inverse}",
         "fallback": "{sys.color.fg.inverse}"
       },
       "light": {
@@ -237,7 +237,7 @@
         "value": "{sys.color.fg.inverse}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "replace neutral.accent with {sys.color.fg.inverse}",
+        "deprecatedComment": "replace neutral.accent with {system.color.fg.inverse}",
         "fallback": "{sys.color.fg.inverse}"
       },
       "lighter": {

--- a/tokens/deprecated/sys/color/color.json
+++ b/tokens/deprecated/sys/color/color.json
@@ -7,42 +7,42 @@
           "type": "color",
           "description": "Surface",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.primary.default instead"
+          "deprecatedComment": "Use system.color.brand.surface.primary.default instead"
         },
         "softer": {
           "value": "{sys.color.brand.surface.primary.strong}",
           "type": "color",
           "description": "Select",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.primary.strong tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.primary.strong tokens instead"
         },
         "soft": {
           "value": "{sys.color.brand.surface.primary.default}",
           "type": "color",
           "description": "Primary disabled",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.primary.default tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.primary.default tokens instead"
         },
         "default": {
           "value": "{sys.color.brand.accent.primary}",
           "type": "color",
           "description": "Primary brand color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.primary instead"
+          "deprecatedComment": "Use system.color.brand.accent.primary instead"
         },
         "strong": {
           "value": "{sys.color.brand.accent.primary}",
           "type": "color",
           "description": "Brand hover background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.primary instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.accent.primary instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.accent.primary}",
           "type": "color",
           "description": "Brand active background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.primary instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.accent.primary instead with system.color.accent.overlay.pressed"
         }
       },
       "transparent": {
@@ -51,21 +51,21 @@
           "type": "color",
           "description": "Transparent background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.transparent instead"
+          "deprecatedComment": "Use system.color.surface.transparent instead"
         },
         "strong": {
           "value": "{sys.color.surface.overlay.hover.default}",
           "type": "color",
           "description": "Inverse Secondary Button Hover state",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.overlay.hover tokens instead"
+          "deprecatedComment": "Use system.color.surface.overlay.hover tokens instead"
         },
         "stronger": {
           "value": "{sys.color.surface.overlay.pressed.default}",
           "type": "color",
           "description": "Inverse Secondary Button Active state",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.overlay.pressed tokens instead"
+          "deprecatedComment": "Use system.color.surface.overlay.pressed tokens instead"
         }
       },
       "overlay": {
@@ -73,14 +73,14 @@
         "type": "color",
         "description": "Overlay background",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.surface.overlay.scrim instead"
+        "deprecatedComment": "Use system.color.surface.overlay.scrim instead"
       },
       "translucent": {
         "value": "{sys.color.surface.contrast.default}",
         "type": "color",
         "description": "Tooltip, Status Indicator",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.surface.contrast.default tokens instead"
+        "deprecatedComment": "Use system.color.surface.contrast.default tokens instead"
       },
       "alt": {
         "softer": {
@@ -88,28 +88,28 @@
           "type": "color",
           "description": "Disabled inputs",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.raised tokens instead"
+          "deprecatedComment": "Use system.color.surface.raised tokens instead"
         },
         "soft": {
           "value": "{sys.color.surface.alt.default}",
           "type": "color",
           "description": "Alternative page background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.alt.default instead"
+          "deprecatedComment": "Use system.color.surface.alt.default instead"
         },
         "strong": {
           "value": "{sys.color.surface.alt.default}",
           "type": "color",
           "description": "Active states",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.default tokens instead with sys.color.surface.overlay.hover"
+          "deprecatedComment": "Use system.color.surface.default tokens instead with system.color.surface.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.surface.alt.default}",
           "type": "color",
           "description": "Active state for segmented control, Pill",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.alt.default with sys.color.surface.overlay.pressed"
+          "deprecatedComment": "Use system.color.surface.alt.default with system.color.surface.overlay.pressed"
         }
       },
       "muted": {
@@ -117,25 +117,25 @@
           "value": "{sys.color.accent.muted.soft}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.muted.soft token instead"
+          "deprecatedComment": "Use system.color.accent.muted.soft token instead"
         },
         "soft": {
           "value": "{sys.color.accent.muted.soft}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.muted.soft token instead"
+          "deprecatedComment": "Use system.color.accent.muted.soft token instead"
         },
         "default": {
           "value": "{sys.color.accent.muted.default}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.muted.default instead"
+          "deprecatedComment": "Use system.color.accent.muted.default instead"
         },
         "strong": {
           "value": "{sys.color.accent.muted.default}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.muted.default token instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.accent.muted.default token instead with system.color.accent.overlay.hover"
         }
       },
       "contrast": {
@@ -144,14 +144,14 @@
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.contrast.default instead"
+          "deprecatedComment": "Use system.color.surface.contrast.default instead"
         },
         "strong": {
           "value": "{sys.color.surface.contrast.strong}",
           "type": "color",
           "description": "Contrast backgrounds, like Secondary Buttons",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.contrast.strong with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.surface.contrast.strong with system.color.accent.overlay.hover"
         }
       },
       "positive": {
@@ -160,42 +160,42 @@
           "type": "color",
           "description": "Lightest surface success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.success tokens instead"
+          "deprecatedComment": "Use system.color.surface.success tokens instead"
         },
         "softer": {
           "value": "{sys.color.brand.surface.positive.strong}",
           "type": "color",
           "description": "Surface success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.positive.strong tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.positive.strong tokens instead"
         },
         "soft": {
           "value": "{sys.color.brand.surface.positive.default}",
           "type": "color",
           "description": "Disabled success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.positive.default tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.positive.default tokens instead"
         },
         "default": {
           "value": "{sys.color.brand.accent.positive}",
           "type": "color",
           "description": "Disabled success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.success instead"
+          "deprecatedComment": "Use system.color.accent.success instead"
         },
         "strong": {
           "value": "{sys.color.brand.accent.positive}",
           "type": "color",
           "description": "Hover success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.positive instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.accent.positive instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.accent.positive}",
           "type": "color",
           "description": "Active success background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.positive instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.accent.positive instead with system.color.accent.overlay.pressed"
         }
       },
       "caution": {
@@ -204,42 +204,42 @@
           "type": "color",
           "description": "Disabled warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.caution.default tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.caution.default tokens instead"
         },
         "softer": {
           "value": "{sys.color.brand.surface.caution.strong}",
           "type": "color",
           "description": "Softer warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.caution.strong tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.caution.strong tokens instead"
         },
         "soft": {
           "value": "{palette.amber.100}",
           "type": "color",
           "description": "Softer warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.warning tokens instead"
+          "deprecatedComment": "Use system.color.surface.warning tokens instead"
         },
         "default": {
           "value": "{sys.color.brand.accent.caution}",
           "type": "color",
           "description": "Default warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.caution instead"
+          "deprecatedComment": "Use system.color.brand.accent.caution instead"
         },
         "strong": {
           "value": "{sys.color.brand.accent.caution}",
           "type": "color",
           "description": "Strong warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.caution instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.accent.caution instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.accent.caution}",
           "type": "color",
           "description": "Stronger warning background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.caution instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.accent.caution instead with system.color.accent.overlay.pressed"
         }
       },
       "critical": {
@@ -248,42 +248,42 @@
           "type": "color",
           "description": "Input error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.critical.default tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.critical.default tokens instead"
         },
         "softer": {
           "value": "{sys.color.brand.surface.critical.strong}",
           "type": "color",
           "description": "Disabled error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.surface.critical.strong tokens instead"
+          "deprecatedComment": "Use system.color.brand.surface.critical.strong tokens instead"
         },
         "soft": {
           "value": "{palette.red.100}",
           "type": "color",
           "description": "Disabled error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.danger tokens instead"
+          "deprecatedComment": "Use system.color.surface.danger tokens instead"
         },
         "default": {
           "value": "{sys.color.brand.accent.critical}",
           "type": "color",
           "description": "Default error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.critical instead"
+          "deprecatedComment": "Use system.color.brand.accent.critical instead"
         },
         "strong": {
           "value": "{sys.color.brand.accent.critical}",
           "type": "color",
           "description": "Strong error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.critical instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.accent.critical instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.accent.critical}",
           "type": "color",
           "description": "Stronger error background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.accent.critical instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.accent.critical instead with system.color.accent.overlay.pressed"
         }
       },
       "ai": {
@@ -292,28 +292,28 @@
           "type": "color",
           "description": "AI container",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.ai.default instead"
+          "deprecatedComment": "Use system.color.surface.ai.default instead"
         },
         "strong": {
           "value": "{sys.color.surface.ai.hover}",
           "type": "color",
           "description": "Hover on AI container",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.ai.hover instead"
+          "deprecatedComment": "Use system.color.surface.ai.hover instead"
         },
         "stronger": {
           "value": "{sys.color.surface.ai.pressed}",
           "type": "color",
           "description": "Active state on AI containers",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.ai.pressed instead"
+          "deprecatedComment": "Use system.color.surface.ai.pressed instead"
         },
         "strongest": {
           "value": "{sys.color.accent.ai}",
           "type": "color",
           "description": "AI surfaces",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.ai instead"
+          "deprecatedComment": "Use system.color.accent.ai instead"
         }
       },
       "info": {
@@ -322,42 +322,42 @@
           "type": "color",
           "description": "Surface",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.info.default instead"
+          "deprecatedComment": "Use system.color.surface.info.default instead"
         },
         "softer": {
           "value": "{sys.color.surface.info.strong}",
           "type": "color",
           "description": "Select",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.info.strong instead"
+          "deprecatedComment": "Use system.color.surface.info.strong instead"
         },
         "soft": {
           "value": "{sys.color.surface.info.default}",
           "type": "color",
           "description": "Disabled",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.info.default tokens instead"
+          "deprecatedComment": "Use system.color.surface.info.default tokens instead"
         },
         "default": {
           "value": "{sys.color.accent.info}",
           "type": "color",
           "description": "Info color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.info instead"
+          "deprecatedComment": "Use system.color.accent.info instead"
         },
         "strong": {
           "value": "{sys.color.accent.info}",
           "type": "color",
           "description": "Brand hover background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.info instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.accent.info instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.accent.info}",
           "type": "color",
           "description": "Brand active background",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.info instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.accent.info instead with system.color.accent.overlay.pressed"
         }
       }
     },
@@ -367,21 +367,21 @@
         "type": "color",
         "description": "Body text",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.default instead"
+        "deprecatedComment": "Use system.color.fg.default instead"
       },
       "strong": {
         "value": "{sys.color.fg.strong}",
         "type": "color",
         "description": "Heading text",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.strong instead"
+        "deprecatedComment": "Use system.color.fg.strong instead"
       },
       "stronger": {
         "value": "{sys.color.fg.strong}",
         "type": "color",
         "description": "Display text",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.strong instead"
+        "deprecatedComment": "Use system.color.fg.strong instead"
       },
       "disabled": {
         "value": "{palette.slate.400}",
@@ -395,14 +395,14 @@
         "type": "color",
         "description": "Hint text color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.muted.default instead"
+        "deprecatedComment": "Use system.color.fg.muted.default instead"
       },
       "inverse": {
         "value": "{sys.color.fg.inverse}",
         "type": "color",
         "description": "Inverse text color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.inverse instead"
+        "deprecatedComment": "Use system.color.fg.inverse instead"
       },
       "critical": {
         "default": {
@@ -410,35 +410,35 @@
           "type": "color",
           "description": "Error text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.critical.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.critical.strong}",
           "type": "color",
           "description": "Error text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.critical.strong instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.critical.strong}",
           "type": "color",
           "description": "Error text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.critical.strong instead"
         },
         "soft": {
           "value": "{palette.red.400}",
           "type": "color",
           "description": "Error text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         },
         "softer": {
           "value": "{palette.red.200}",
           "type": "color",
           "description": "Error text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         }
       },
       "primary": {
@@ -447,35 +447,35 @@
           "type": "color",
           "description": "Branded text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Branded hover text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong instead"
         },
         "soft": {
           "value": "{palette.blue.400}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         },
         "softer": {
           "value": "{palette.blue.200}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         }
       },
       "caution": {
@@ -484,42 +484,42 @@
           "type": "color",
           "description": "Warning text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         },
         "strong": {
           "value": "{sys.color.fg.contrast.strong}",
           "type": "color",
           "description": "Strong warning text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.contrast.strong instead"
+          "deprecatedComment": "Use system.color.fg.contrast.strong instead"
         },
         "soft": {
           "value": "{palette.amber.400}",
           "type": "color",
           "description": "Disabled warning text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         },
         "stronger": {
           "value": "{sys.color.fg.contrast.strong}",
           "type": "color",
           "description": "Stronger warning text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.contrast.strong instead"
+          "deprecatedComment": "Use system.color.fg.contrast.strong instead"
         },
         "softer": {
           "value": "{palette.amber.200}",
           "type": "color",
           "description": "Softer warning text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         }
       },
       "ai": {
         "value": "{palette.blue.950}",
         "type": "color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.ai instead"
+        "deprecatedComment": "Use system.color.fg.ai instead"
       },
       "positive": {
         "default": {
@@ -527,35 +527,35 @@
           "type": "color",
           "description": "Branded text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.positive.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Branded hover text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead"
         },
         "soft": {
           "value": "{palette.green.400}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         },
         "softer": {
           "value": "{palette.green.200}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         }
       },
       "info": {
@@ -564,35 +564,35 @@
           "type": "color",
           "description": "Branded text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.default instead"
+          "deprecatedComment": "Use system.color.fg.info.default instead"
         },
         "strong": {
           "value": "{sys.color.fg.info.strong}",
           "type": "color",
           "description": "Branded hover text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.strong instead"
+          "deprecatedComment": "Use system.color.fg.info.strong instead"
         },
         "stronger": {
           "value": "{sys.color.fg.info.strong}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.strong instead"
+          "deprecatedComment": "Use system.color.fg.info.strong instead"
         },
         "soft": {
           "value": "{palette.blue.400}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.default instead"
+          "deprecatedComment": "Use system.color.fg.info.default instead"
         },
         "softer": {
           "value": "{palette.blue.200}",
           "type": "color",
           "description": "Active links",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         }
       }
     },
@@ -602,28 +602,28 @@
         "type": "color",
         "description": "Default icon color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.default instead"
+        "deprecatedComment": "Use system.color.fg.default instead"
       },
       "soft": {
         "value": "{sys.color.fg.muted.default}",
         "type": "color",
         "description": "Disabled icon color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.muted.default instead"
+        "deprecatedComment": "Use system.color.fg.muted.default instead"
       },
       "strong": {
         "value": "{sys.color.fg.muted.strong}",
         "type": "color",
         "description": "Hover icon color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.muted.strong instead"
+        "deprecatedComment": "Use system.color.fg.muted.strong instead"
       },
       "inverse": {
         "value": "{palette.neutral.0}",
         "type": "color",
         "description": "Inverse icon color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.inverse instead"
+        "deprecatedComment": "Use system.color.fg.inverse instead"
       },
       "primary": {
         "default": {
@@ -631,35 +631,35 @@
           "type": "color",
           "description": "Brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong instead"
         },
         "soft": {
           "value": "{palette.blue.400}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         },
         "softer": {
           "value": "{palette.blue.200}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         }
       },
       "positive": {
@@ -668,35 +668,35 @@
           "type": "color",
           "description": "Success icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.positive.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Success icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Success icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead with system.color.accent.overlay.pressed"
         },
         "soft": {
           "value": "{palette.green.400}",
           "type": "color",
           "description": "Success icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         },
         "softer": {
           "value": "{palette.green.200}",
           "type": "color",
           "description": "Success icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         }
       },
       "critical": {
@@ -705,35 +705,35 @@
           "type": "color",
           "description": "Error icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.critical.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.critical.strong}",
           "type": "color",
           "description": "Error icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger-strong instead"
+          "deprecatedComment": "Use system.color.fg.danger-strong instead"
         },
         "stronger": {
           "value": "{palette.red.800}",
           "type": "color",
           "description": "Error icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger.strong instead"
+          "deprecatedComment": "Use system.color.fg.danger.strong instead"
         },
         "soft": {
           "value": "{palette.red.400}",
           "type": "color",
           "description": "Error icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         },
         "softer": {
           "value": "{palette.red.200}",
           "type": "color",
           "description": "Error icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         }
       },
       "caution": {
@@ -742,35 +742,35 @@
           "type": "color",
           "description": "Caution icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.contrast.default instead"
+          "deprecatedComment": "Use system.color.fg.contrast.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.caution.default}",
           "type": "color",
           "description": "Strong caution icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.caution.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.caution.default instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.caution.strong}",
           "type": "color",
           "description": "Strong caution icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.caution.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.caution.strong instead"
         },
         "soft": {
           "value": "{sys.color.brand.fg.caution.default}",
           "type": "color",
           "description": "Soft caution icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         },
         "softer": {
           "value": "{palette.amber.500}",
           "type": "color",
           "description": "Softer caution icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         }
       },
       "disabled": {
@@ -778,7 +778,7 @@
         "type": "color",
         "description": "Disabled icon color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.fg.disabled instead"
+        "deprecatedComment": "Use system.color.fg.disabled instead"
       },
       "info": {
         "default": {
@@ -786,21 +786,21 @@
           "type": "color",
           "description": "Brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.default instead"
+          "deprecatedComment": "Use system.color.fg.info.default instead"
         },
         "strong": {
           "value": "{sys.color.fg.info.strong}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.strong instead"
+          "deprecatedComment": "Use system.color.fg.info.strong instead"
         },
         "stronger": {
           "value": "{palette.blue.800}",
           "type": "color",
           "description": "Stronger brand icon color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.strong instead"
+          "deprecatedComment": "Use system.color.fg.info.strong instead"
         }
       }
     },
@@ -811,35 +811,35 @@
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.critical.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.critical.strong}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.critical.strong instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.fg.critical.strong instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{palette.red.800}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger tokens instead"
+          "deprecatedComment": "Use system.color.fg.danger tokens instead"
         },
         "soft": {
           "value": "{palette.red.400}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         },
         "softer": {
           "value": "{palette.red.200}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.danger instead"
+          "deprecatedComment": "Use system.color.fg.danger instead"
         }
       },
       "muted": {
@@ -847,14 +847,14 @@
           "value": "{sys.color.fg.muted.strong}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.muted.strong instead"
+          "deprecatedComment": "Use system.color.fg.muted.strong instead"
         },
         "soft": {
           "value": "{palette.slate.400}",
           "type": "color",
           "description": "Tab item foreground",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.muted instead"
+          "deprecatedComment": "Use system.color.fg.muted instead"
         }
       },
       "primary": {
@@ -863,34 +863,34 @@
           "type": "color",
           "description": "Branded text",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.default instead"
         },
         "soft": {
           "value": "{palette.blue.400}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info or sys.color.brand.fg.primary instead"
+          "deprecatedComment": "Use system.color.fg.info or system.color.brand.fg.primary instead"
         },
         "softer": {
           "value": "{palette.blue.200}",
           "type": "color",
           "description": "Link Inverse, Disabled",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info or sys.color.brand.fg.primary instead"
+          "deprecatedComment": "Use system.color.fg.info or system.color.brand.fg.primary instead"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Links on hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong  instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong  instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.primary.strong}",
           "type": "color",
           "description": "Links on hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.primary.strong instead"
+          "deprecatedComment": "Use system.color.brand.fg.primary.strong instead"
         }
       },
       "caution": {
@@ -899,35 +899,35 @@
           "type": "color",
           "description": "Warning",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.caution.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.caution.default instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.caution.strong}",
           "type": "color",
           "description": "Warning on hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.caution.strong instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.fg.caution.strong instead with system.color.accent.overlay.hover"
         },
         "soft": {
           "value": "{palette.amber.700}",
           "type": "color",
           "description": "Warning",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         },
         "stronger": {
           "value": "{palette.amber.975}",
           "type": "color",
           "description": "Warning on hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning-strong instead"
+          "deprecatedComment": "Use system.color.fg.warning-strong instead"
         },
         "softer": {
           "value": "{palette.amber.500}",
           "type": "color",
           "description": "Warning",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning instead"
+          "deprecatedComment": "Use system.color.fg.warning instead"
         }
       },
       "info": {
@@ -936,20 +936,20 @@
           "type": "color",
           "description": "Link Inverse, Disabled",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.ai instead"
+          "deprecatedComment": "Use system.color.fg.ai instead"
         },
         "soft": {
           "value": "{palette.blue.400}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info instead"
+          "deprecatedComment": "Use system.color.fg.info instead"
         },
         "stronger": {
           "value": "{sys.color.fg.info.strong}",
           "type": "color",
           "description": "Links on hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.info.strong instead"
+          "deprecatedComment": "Use system.color.fg.info.strong instead"
         }
       },
       "positive": {
@@ -958,35 +958,35 @@
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.default instead"
+          "deprecatedComment": "Use system.color.brand.fg.positive.default instead"
         },
         "softer": {
           "value": "{palette.green.200}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         },
         "soft": {
           "value": "{palette.green.400}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.success instead"
+          "deprecatedComment": "Use system.color.fg.success instead"
         },
         "strong": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead with sys.color.accent.overlay.hover"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead with system.color.accent.overlay.hover"
         },
         "stronger": {
           "value": "{sys.color.brand.fg.positive.strong}",
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.fg.positive.strong instead with sys.color.accent.overlay.pressed"
+          "deprecatedComment": "Use system.color.brand.fg.positive.strong instead with system.color.accent.overlay.pressed"
         }
       }
     },
@@ -996,7 +996,7 @@
         "type": "color",
         "description": "Active state on AI borders",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.accent.ai instead"
+        "deprecatedComment": "Use system.color.accent.ai instead"
       },
       "input": {
         "disabled": {
@@ -1004,21 +1004,21 @@
           "type": "color",
           "description": "Disabled inputs",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.disabled instead"
+          "deprecatedComment": "Use system.color.fg.disabled instead"
         },
         "strong": {
           "value": "{sys.color.border.input.hover}",
           "type": "color",
           "description": "Input hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.border.input.hover instead"
+          "deprecatedComment": "Use system.color.border.input.hover instead"
         },
         "inverse": {
           "value": "{sys.color.border.inverse.default}",
           "type": "color",
           "description": "Borders on checkboxes and radios",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.border.inverse.default instead"
+          "deprecatedComment": "Use system.color.border.inverse.default instead"
         }
       },
       "contrast": {
@@ -1027,7 +1027,7 @@
           "type": "color",
           "description": "Secondary Button Hover",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.border.contrast.default instead"
+          "deprecatedComment": "Use system.color.border.contrast.default instead"
         }
       },
       "critical": {
@@ -1036,7 +1036,7 @@
           "type": "color",
           "description": "Error",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.border.critical instead"
+          "deprecatedComment": "Use system.color.brand.border.critical instead"
         }
       },
       "caution": {
@@ -1045,14 +1045,14 @@
           "type": "color",
           "description": "Warning inner",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.focus.caution.inner instead"
+          "deprecatedComment": "Use system.color.brand.focus.caution.inner instead"
         },
         "strong": {
           "value": "{sys.color.brand.focus.caution.outer}",
           "type": "color",
           "description": "Warning outer (box shadow)",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.focus.caution.outer instead"
+          "deprecatedComment": "Use system.color.brand.focus.caution.outer instead"
         }
       },
       "divider": {
@@ -1060,7 +1060,7 @@
         "type": "color",
         "description": "Dividers",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.border.default instead"
+        "deprecatedComment": "Use system.color.border.default instead"
       },
       "primary": {
         "default": {
@@ -1068,7 +1068,7 @@
           "type": "color",
           "description": "Brand, Focus",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.brand.border.primary instead"
+          "deprecatedComment": "Use system.color.brand.border.primary instead"
         }
       },
       "container": {
@@ -1076,7 +1076,7 @@
         "type": "color",
         "description": "Cards, Toasts, Surfaces",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.border.strong or sys.color.border.strong instead"
+        "deprecatedComment": "Use system.color.border.strong or system.color.border.strong instead"
       }
     },
     "shadow": {
@@ -1085,21 +1085,21 @@
         "type": "color",
         "description": "First shadow color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.shadow.base instead"
+        "deprecatedComment": "Use system.color.shadow.base instead"
       },
       "2": {
         "value": "{sys.color.shadow.ambient}",
         "type": "color",
         "description": "Second shadow color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.shadow.ambient instead"
+        "deprecatedComment": "Use system.color.shadow.ambient instead"
       },
       "default": {
         "value": "{sys.color.shadow.base}",
         "type": "color",
         "description": "Main shadow color",
         "deprecated": true,
-        "deprecatedComment": "Use sys.color.shadow.base instead"
+        "deprecatedComment": "Use system.color.shadow.base instead"
       }
     },
     "static": {
@@ -1108,7 +1108,7 @@
           "value": "{palette.amber.600}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace static.gold.stronger with {sys.color.static.amber.stronger}. Prefer to replace with `sys.color.bg.caution.stronger` if used as a background color."
+          "deprecatedComment": "replace static.gold.stronger with {system.color.static.amber.stronger}. Prefer to replace with `system.color.bg.caution.stronger` if used as a background color."
         }
       },
       "orange": {
@@ -1116,19 +1116,19 @@
           "value": "{palette.amber.400}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace static.orange.default with {sys.color.static.amber.default}. Prefer to replace with `sys.color.bg.caution.default` if used as a background color."
+          "deprecatedComment": "replace static.orange.default with {system.color.static.amber.default}. Prefer to replace with `system.color.bg.caution.default` if used as a background color."
         },
         "soft": {
           "value": "{palette.amber.100}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace static.orange.soft with {sys.color.static.amber.soft}. Prefer to replace with `sys.color.bg.caution.soft` if used as a background color."
+          "deprecatedComment": "replace static.orange.soft with {system.color.static.amber.soft}. Prefer to replace with `system.color.bg.caution.soft` if used as a background color."
         },
         "strong": {
           "value": "{palette.amber.500}",
           "type": "color",
           "deprecated": true,
-          "deprecatedComment": "replace static.orange.strong with {sys.color.static.amber.strong}. Prefer to replace with `sys.color.bg.caution.strong` if used as a background color."
+          "deprecatedComment": "replace static.orange.strong with {system.color.static.amber.strong}. Prefer to replace with `system.color.bg.caution.strong` if used as a background color."
         }
       },
       "blue": {
@@ -1137,7 +1137,7 @@
           "type": "color",
           "description": "Blue",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.info instead"
+          "deprecatedComment": "Use system.color.accent.info instead"
         },
         "softest": {
           "value": "{palette.blue.25}",
@@ -1355,28 +1355,28 @@
           "type": "color",
           "description": "amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.warning token instead"
+          "deprecatedComment": "Use system.color.accent.warning token instead"
         },
         "softest": {
           "value": "{sys.color.surface.warning.default}",
           "type": "color",
           "description": "Soft amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.warning instead"
+          "deprecatedComment": "Use system.color.accent.warning instead"
         },
         "strong": {
           "value": "{sys.color.accent.warning}",
           "type": "color",
           "description": "Stronger amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.warning instead"
+          "deprecatedComment": "Use system.color.accent.warning instead"
         },
         "stronger": {
           "value": "{sys.color.accent.warning}",
           "type": "color",
           "description": "Stronger amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.accent.warning instead"
+          "deprecatedComment": "Use system.color.accent.warning instead"
         },
         "softer": {
           "value": "{palette.amber.50}",
@@ -1390,14 +1390,14 @@
           "type": "color",
           "description": "Stronger amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.fg.warning.strong instead"
+          "deprecatedComment": "Use system.color.fg.warning.strong instead"
         },
         "soft": {
           "value": "{sys.color.surface.warning.strong}",
           "type": "color",
           "description": "Soft amber",
           "deprecated": true,
-          "deprecatedComment": "Use sys.color.surface.warning.strong instead"
+          "deprecatedComment": "Use system.color.surface.warning.strong instead"
         }
       }
     }


### PR DESCRIPTION
The deprecated comments referenced `sys.` tokens, when they should say `system.` tokens.