### PR TITLE
fix: Update pressed color value from A200 to 400

### DIFF
--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -92,7 +92,7 @@
           "type": "color"
         },
         "pressed": {
-          "value": "{palette.blue.A200}",
+          "value": "{palette.blue.400}",
           "type": "color"
         }
       },


### PR DESCRIPTION
Figma updated as well

## Overview

Fixes value for pressed on surface/ai

## Checks

- [x] Overview Added
- [x] Deprecated tokens placed in `deprecated` folder
- [x] Deprecated tokens file structure is the same as main.
- [x] Main tokens file doesn't have deprecated tokens.
- [x] Math values have spaces around math sign.

## Thank You Gif

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer: -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
