### PR TITLE
feat: Add dark palette

### DIFF
--- a/tokens/base/palette.json
+++ b/tokens/base/palette.json
@@ -1,13 +1,868 @@
 {
   "palette": {
+    "black": {
+      "$root": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#000000"
+        }
+      },
+      "A0": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.0,
+          "hex": "#00000000"
+        }
+      },
+      "A25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.023,
+          "hex": "#00000006"
+        }
+      },
+      "A50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.045,
+          "hex": "#0000000B"
+        }
+      },
+      "A100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.118,
+          "hex": "#0000001E"
+        }
+      },
+      "A150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.1841,
+          "hex": "#0000002F"
+        }
+      },
+      "A200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.25,
+          "hex": "#00000040"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.374,
+          "hex": "#0000005F"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.489,
+          "hex": "#0000007D"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.591,
+          "hex": "#00000097"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.698,
+          "hex": "#000000B2"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.788,
+          "hex": "#000000C9"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.861,
+          "hex": "#000000DC"
+        }
+      },
+      "A850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.8909,
+          "hex": "#000000E3"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.921,
+          "hex": "#000000EB"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.947,
+          "hex": "#000000F1"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.974,
+          "hex": "#000000F8"
+        }
+      }
+    },
+    "white": {
+      "A0": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.0,
+          "hex": "#FFFFFF00"
+        }
+      },
+      "A25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.023,
+          "hex": "#FFFFFF06"
+        }
+      },
+      "A50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.045,
+          "hex": "#FFFFFF0B"
+        }
+      },
+      "A100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.118,
+          "hex": "#FFFFFF1E"
+        }
+      },
+      "A150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.1841,
+          "hex": "#FFFFFF2F"
+        }
+      },
+      "A200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.25,
+          "hex": "#FFFFFF40"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.374,
+          "hex": "#FFFFFF5F"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.489,
+          "hex": "#FFFFFF7D"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.591,
+          "hex": "#FFFFFF97"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.698,
+          "hex": "#FFFFFFB2"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.788,
+          "hex": "#FFFFFFC9"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.861,
+          "hex": "#FFFFFFDC"
+        }
+      },
+      "A850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.8909,
+          "hex": "#FFFFFFE3"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.921,
+          "hex": "#FFFFFFEB"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.947,
+          "hex": "#FFFFFFF1"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 0.974,
+          "hex": "#FFFFFFF8"
+        }
+      },
+      "$root": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [1.0, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#FFFFFF",
+          "description": "Brand anchor: Paper"
+        }
+      }
+    },
+    "neutral": {
+      "25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9851, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#FAFAFA"
+        }
+      },
+      "50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9702, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#F5F5F5"
+        }
+      },
+      "100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9431, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#ECECEC"
+        }
+      },
+      "150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9067, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#E0E0E0"
+        }
+      },
+      "200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.8699, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#D4D4D4"
+        }
+      },
+      "300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.8047, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#BFBFBF"
+        }
+      },
+      "400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7219, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#A5A5A5"
+        }
+      },
+      "500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6234, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#878787"
+        }
+      },
+      "600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5103, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#666666"
+        }
+      },
+      "700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4386, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#525252"
+        }
+      },
+      "800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3171, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#323232"
+        }
+      },
+      "850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2645, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#252525"
+        }
+      },
+      "900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2478, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#212121"
+        }
+      },
+      "950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2264, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#1C1C1C"
+        }
+      },
+      "975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1957, 0.0, 0.0],
+          "alpha": 1.0,
+          "hex": "#151515"
+        }
+      },
+      "A25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.0196,
+          "hex": "#00000005"
+        }
+      },
+      "A50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.0392,
+          "hex": "#0000000A"
+        }
+      },
+      "A100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.0745,
+          "hex": "#00000013"
+        }
+      },
+      "A150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.1216,
+          "hex": "#0000001F"
+        }
+      },
+      "A200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.1686,
+          "hex": "#0000002B"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.251,
+          "hex": "#00000040"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.3529,
+          "hex": "#0000005A"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.4706,
+          "hex": "#00000078"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.6,
+          "hex": "#00000099"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.6784,
+          "hex": "#000000AD"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.8039,
+          "hex": "#000000CD"
+        }
+      },
+      "A850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.8549,
+          "hex": "#000000DA"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.8706,
+          "hex": "#000000DE"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.8902,
+          "hex": "#000000E3"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.0, 0.0, 0.0],
+          "alpha": 0.9176,
+          "hex": "#000000EA"
+        }
+      }
+    },
+    "slate": {
+      "25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9849, 0.0029, 264.51],
+          "alpha": 1.0,
+          "hex": "#F9FAFC"
+        }
+      },
+      "50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9695, 0.0046, 258.42],
+          "alpha": 1.0,
+          "hex": "#F3F5F8"
+        }
+      },
+      "100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.9442, 0.007, 248.08],
+          "alpha": 1.0,
+          "hex": "#E9EDF1"
+        }
+      },
+      "150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.908, 0.011, 256.75],
+          "alpha": 1.0,
+          "hex": "#DCE1E8"
+        }
+      },
+      "200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.8706, 0.0158, 257.24],
+          "alpha": 1.0,
+          "hex": "#CED5DF"
+        }
+      },
+      "300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.804, 0.0215, 254.97],
+          "alpha": 1.0,
+          "hex": "#B6C0CD"
+        }
+      },
+      "400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7209, 0.0239, 254.47],
+          "alpha": 1.0,
+          "hex": "#9BA6B4"
+        }
+      },
+      "500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6225, 0.0248, 254.49],
+          "alpha": 1.0,
+          "hex": "#7D8896"
+        }
+      },
+      "600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5099, 0.0241, 255.03],
+          "alpha": 1.0,
+          "hex": "#5D6774"
+        }
+      },
+      "700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4388, 0.0229, 255.66],
+          "alpha": 1.0,
+          "hex": "#4A535F"
+        }
+      },
+      "800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3147, 0.0128, 253.03],
+          "alpha": 1.0,
+          "hex": "#2D3238"
+        }
+      },
+      "850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2667, 0.011, 254.05],
+          "alpha": 1.0,
+          "hex": "#22262B"
+        }
+      },
+      "900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2458, 0.0112, 254.07],
+          "alpha": 1.0,
+          "hex": "#1D2126"
+        }
+      },
+      "950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2202, 0.0116, 254.1],
+          "alpha": 1.0,
+          "hex": "#171B20"
+        }
+      },
+      "975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1933, 0.0102, 248.38],
+          "alpha": 1.0,
+          "hex": "#111519"
+        }
+      },
+      "A25": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3276, 0.1499, 261.85],
+          "alpha": 0.0235,
+          "hex": "#002A8006"
+        }
+      },
+      "A50": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3064, 0.1202, 259.24],
+          "alpha": 0.0471,
+          "hex": "#002A6A0C"
+        }
+      },
+      "A100": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3039, 0.0952, 253.5],
+          "alpha": 0.0863,
+          "hex": "#002E5D16"
+        }
+      },
+      "A150": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2742, 0.101, 257.89],
+          "alpha": 0.1373,
+          "hex": "#00245723"
+        }
+      },
+      "A200": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2751, 0.1026, 258.15],
+          "alpha": 0.1922,
+          "hex": "#00245831"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2639, 0.0924, 256.67],
+          "alpha": 0.2863,
+          "hex": "#00235049"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2307, 0.0767, 255.26],
+          "alpha": 0.3922,
+          "hex": "#001C4064"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1993, 0.0626, 253.59],
+          "alpha": 0.5098,
+          "hex": "#00163182"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1704, 0.05, 251.35],
+          "alpha": 0.6353,
+          "hex": "#001024A2"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1549, 0.0434, 249.61],
+          "alpha": 0.7098,
+          "hex": "#000D1EB5"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1165, 0.026, 238.48],
+          "alpha": 0.8235,
+          "hex": "#00060DD2"
+        }
+      },
+      "A850": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1063, 0.0237, 238.42],
+          "alpha": 0.8667,
+          "hex": "#00050ADD"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1055, 0.0236, 238.41],
+          "alpha": 0.8863,
+          "hex": "#00050AE2"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1046, 0.0233, 238.41],
+          "alpha": 0.9098,
+          "hex": "#00040AE8"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1028, 0.0214, 233.52],
+          "alpha": 0.9333,
+          "hex": "#000409EE"
+        }
+      }
+    },
     "amber": {
       "25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
           "components": [0.9779, 0.0214, 95.33],
-          "alpha": 1,
-          "hex": "#fcf8e8",
+          "alpha": 1.0,
+          "hex": "#FCF8E8",
           "description": "Brand anchor: Keyboard"
         }
       },
@@ -15,9 +870,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.969, 0.0619, 101.63],
-          "alpha": 1,
-          "hex": "#fdf7c7"
+          "components": [0.969, 0.062, 101.58],
+          "alpha": 1.0,
+          "hex": "#FDF7C7"
         }
       },
       "100": {
@@ -25,8 +880,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9567, 0.0948, 100.22],
-          "alpha": 1,
-          "hex": "#fff3a8",
+          "alpha": 1.0,
+          "hex": "#FFF3A8",
           "description": "Brand anchor: Highlighter"
         }
       },
@@ -35,8 +890,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9191, 0.1547, 99.7],
-          "alpha": 1,
-          "hex": "#fde65e",
+          "alpha": 1.0,
+          "hex": "#FDE65E",
           "description": "Brand anchor: Pencil"
         }
       },
@@ -44,9 +899,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8432, 0.1713, 85.24],
-          "alpha": 1,
-          "hex": "#fec10b",
+          "components": [0.8432, 0.1712, 85.22],
+          "alpha": 1.0,
+          "hex": "#FEC10C",
           "description": "Brand anchor: Lunch"
         }
       },
@@ -55,17 +910,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7909, 0.1711, 70.15],
-          "alpha": 1,
-          "hex": "#ffa400"
+          "alpha": 1.0,
+          "hex": "#FFA400"
         }
       },
       "500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6601, 0.1537, 60.7],
-          "alpha": 1,
-          "hex": "#d47800"
+          "components": [0.6607, 0.1536, 60.87],
+          "alpha": 1.0,
+          "hex": "#D47800"
         }
       },
       "600": {
@@ -73,8 +928,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5505, 0.1439, 50.78],
-          "alpha": 1,
-          "hex": "#b15300"
+          "alpha": 1.0,
+          "hex": "#B15300"
         }
       },
       "700": {
@@ -82,8 +937,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4824, 0.1353, 46.11],
-          "alpha": 1,
-          "hex": "#993f00"
+          "alpha": 1.0,
+          "hex": "#993F00"
         }
       },
       "800": {
@@ -91,17 +946,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4143, 0.1245, 42.21],
-          "alpha": 1,
-          "hex": "#802d00"
+          "alpha": 1.0,
+          "hex": "#802D00"
         }
       },
       "900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.32, 0.098, 41.19],
-          "alpha": 1,
-          "hex": "#5a1c00"
+          "components": [0.3212, 0.0982, 41.31],
+          "alpha": 1.0,
+          "hex": "#5A1C00"
         }
       },
       "950": {
@@ -109,8 +964,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2489, 0.0771, 40.64],
-          "alpha": 1,
-          "hex": "#3e1000"
+          "alpha": 1.0,
+          "hex": "#3E1000"
         }
       },
       "975": {
@@ -118,44 +973,125 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2165, 0.0674, 40.35],
-          "alpha": 1,
-          "hex": "#320b00"
+          "alpha": 1.0,
+          "hex": "#320B00"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7982, 0.159, 92.57],
-          "alpha": 0.1,
-          "hex": "#E1B9191A"
+          "components": [0.7792, 0.1592, 90.57],
+          "alpha": 0.0902,
+          "hex": "#DEB10017"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8864, 0.1845, 100.28],
-          "alpha": 0.22,
-          "hex": "#F6DB0038"
+          "components": [0.8854, 0.1841, 100.16],
+          "alpha": 0.2196,
+          "hex": "#F6DB0138"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8988, 0.185, 97.8],
-          "alpha": 0.35,
-          "hex": "#FFDD0659"
+          "components": [0.8964, 0.1849, 97.38],
+          "alpha": 0.3412,
+          "hex": "#FFDC0157"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.886, 0.1822, 96.83],
-          "alpha": 0.64,
-          "hex": "#FCD803A3"
+          "components": [0.8846, 0.1822, 96.67],
+          "alpha": 0.6314,
+          "hex": "#FCD700A1"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.8372, 0.1718, 83.95],
+          "alpha": 0.9529,
+          "hex": "#FEBE00F3"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7893, 0.1713, 69.67],
+          "alpha": 0.99,
+          "hex": "#FFA300FC"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6578, 0.1538, 60.24],
+          "alpha": 0.99,
+          "hex": "#D47700FC"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5466, 0.1444, 50.04],
+          "alpha": 0.99,
+          "hex": "#B05100FC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4778, 0.1358, 45.31],
+          "alpha": 0.99,
+          "hex": "#983D00FC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4091, 0.125, 41.34],
+          "alpha": 0.99,
+          "hex": "#7F2B00FC"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3148, 0.0984, 40.16],
+          "alpha": 0.99,
+          "hex": "#581A00FC"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2414, 0.0771, 39.1],
+          "alpha": 0.99,
+          "hex": "#3C0E00FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2083, 0.0675, 38.47],
+          "alpha": 0.99,
+          "hex": "#300900FC"
         }
       }
     },
@@ -164,9 +1100,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.981, 0.0131, 220.96],
-          "alpha": 1,
-          "hex": "#f0fbff"
+          "components": [0.981, 0.0129, 221.68],
+          "alpha": 1.0,
+          "hex": "#F0FBFF"
         }
       },
       "50": {
@@ -174,8 +1110,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9549, 0.0295, 223.86],
-          "alpha": 1,
-          "hex": "#dcf5ff"
+          "alpha": 1.0,
+          "hex": "#DCF5FF"
         }
       },
       "100": {
@@ -183,8 +1119,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9321, 0.0425, 227.25],
-          "alpha": 1,
-          "hex": "#ccefff"
+          "alpha": 1.0,
+          "hex": "#CCEFFF"
         }
       },
       "200": {
@@ -192,8 +1128,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8594, 0.0867, 230.07],
-          "alpha": 1,
-          "hex": "#94dcff"
+          "alpha": 1.0,
+          "hex": "#94DCFF"
         }
       },
       "300": {
@@ -201,8 +1137,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7991, 0.107, 239.24],
-          "alpha": 1,
-          "hex": "#79c7fb"
+          "alpha": 1.0,
+          "hex": "#79C7FB"
         }
       },
       "400": {
@@ -210,8 +1146,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7283, 0.1377, 242.63],
-          "alpha": 1,
-          "hex": "#4cb0f6"
+          "alpha": 1.0,
+          "hex": "#4CB0F6"
         }
       },
       "500": {
@@ -219,8 +1155,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6555, 0.1553, 244.48],
-          "alpha": 1,
-          "hex": "#1c98e8",
+          "alpha": 1.0,
+          "hex": "#1C98E8",
           "description": "Brand anchor: Water"
         }
       },
@@ -229,8 +1165,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5174, 0.1257, 243.24],
-          "alpha": 1,
-          "hex": "#006eaa"
+          "alpha": 1.0,
+          "hex": "#006EAA"
         }
       },
       "700": {
@@ -238,8 +1174,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4618, 0.1098, 242.11],
-          "alpha": 1,
-          "hex": "#005e90"
+          "alpha": 1.0,
+          "hex": "#005E90"
         }
       },
       "800": {
@@ -247,16 +1183,16 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3912, 0.0855, 237.05],
-          "alpha": 1,
-          "hex": "#004b6d"
+          "alpha": 1.0,
+          "hex": "#004B6D"
         }
       },
       "900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.326, 0.07, 235.91],
-          "alpha": 1,
+          "components": [0.3258, 0.07, 235.91],
+          "alpha": 1.0,
           "hex": "#003953"
         }
       },
@@ -264,8 +1200,8 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.249, 0.053, 235.41],
-          "alpha": 1,
+          "components": [0.2496, 0.0529, 234.92],
+          "alpha": 1.0,
           "hex": "#002537"
         }
       },
@@ -274,33 +1210,33 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2138, 0.0455, 235.23],
-          "alpha": 1,
-          "hex": "#001c2b"
+          "alpha": 1.0,
+          "hex": "#001C2B"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7487, 0.1547, 233.36],
-          "alpha": 0.06,
-          "hex": "#05BCFF0F"
+          "components": [0.7461, 0.1558, 233.8],
+          "alpha": 0.0588,
+          "hex": "#00BBFF0F"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7394, 0.1572, 235.46],
-          "alpha": 0.14,
-          "hex": "#05B8FF24"
+          "components": [0.7349, 0.1588, 236.3],
+          "alpha": 0.1373,
+          "hex": "#00B6FF23"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7186, 0.1639, 239.76],
+          "components": [0.7185, 0.164, 239.78],
           "alpha": 0.2,
           "hex": "#00AFFF33"
         }
@@ -309,9 +1245,90 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7117, 0.1663, 241.15],
-          "alpha": 0.42,
+          "components": [0.7108, 0.1667, 241.34],
+          "alpha": 0.4196,
           "hex": "#00ACFF6B"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6542, 0.1794, 248.76],
+          "alpha": 0.5255,
+          "hex": "#0094F786"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6376, 0.1794, 249.75],
+          "alpha": 0.702,
+          "hex": "#008EF2B3"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6224, 0.1671, 247.89],
+          "alpha": 0.8902,
+          "hex": "#008BE5E3"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5133, 0.1261, 243.79],
+          "alpha": 0.99,
+          "hex": "#006DA9FC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4571, 0.11, 242.75],
+          "alpha": 0.99,
+          "hex": "#005C8FFC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3854, 0.0853, 237.87],
+          "alpha": 0.99,
+          "hex": "#00496CFC"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3191, 0.0696, 236.95],
+          "alpha": 0.99,
+          "hex": "#003751FC"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2416, 0.0523, 236.37],
+          "alpha": 0.99,
+          "hex": "#002335FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2051, 0.0448, 237.01],
+          "alpha": 0.99,
+          "hex": "#001A29FC"
         }
       }
     },
@@ -321,26 +1338,26 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.969, 0.0155, 248.07],
-          "alpha": 1,
-          "hex": "#edf6ff"
+          "alpha": 1.0,
+          "hex": "#EDF6FF"
         }
       },
       "50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.9523, 0.0239, 248.12],
-          "alpha": 1,
-          "hex": "#e3f1ff"
+          "components": [0.9519, 0.0242, 248.14],
+          "alpha": 1.0,
+          "hex": "#E3F1FF"
         }
       },
       "100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.928, 0.0359, 250.6],
-          "alpha": 1,
-          "hex": "#d6eaff"
+          "components": [0.9287, 0.0358, 249.55],
+          "alpha": 1.0,
+          "hex": "#D6EAFF"
         }
       },
       "200": {
@@ -348,8 +1365,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8627, 0.0701, 250.6],
-          "alpha": 1,
-          "hex": "#b0d6ff"
+          "alpha": 1.0,
+          "hex": "#B0D6FF"
         }
       },
       "300": {
@@ -357,17 +1374,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7933, 0.1076, 252.08],
-          "alpha": 1,
-          "hex": "#88c0ff"
+          "alpha": 1.0,
+          "hex": "#88C0FF"
         }
       },
       "400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.708, 0.1549, 255.41],
-          "alpha": 1,
-          "hex": "#59a2ff"
+          "components": [0.7071, 0.1554, 255.45],
+          "alpha": 1.0,
+          "hex": "#59A2FF"
         }
       },
       "500": {
@@ -375,17 +1392,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6023, 0.2032, 255.68],
-          "alpha": 1,
-          "hex": "#007df6"
+          "alpha": 1.0,
+          "hex": "#007DF6"
         }
       },
       "600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.5198, 0.1782, 256.11],
-          "alpha": 1,
-          "hex": "#0065cc"
+          "components": [0.5198, 0.1783, 256.13],
+          "alpha": 1.0,
+          "hex": "#0065CC"
         }
       },
       "700": {
@@ -393,8 +1410,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4658, 0.1562, 255.5],
-          "alpha": 1,
-          "hex": "#0057ae",
+          "alpha": 1.0,
+          "hex": "#0057AE",
           "description": "Brand anchor: Ballpoint"
         }
       },
@@ -402,8 +1419,8 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.3908, 0.128, 256],
-          "alpha": 1,
+          "components": [0.3908, 0.128, 258.46],
+          "alpha": 1.0,
           "hex": "#114288"
         }
       },
@@ -412,8 +1429,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3152, 0.1054, 261.09],
-          "alpha": 1,
-          "hex": "#0f2e66",
+          "alpha": 1.0,
+          "hex": "#0F2E66",
           "description": "Brand anchor: Ink"
         }
       },
@@ -422,7 +1439,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2452, 0.0752, 254.55],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#022043",
           "description": "Brand anchor: Afterhours"
         }
@@ -431,8 +1448,8 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.209, 0.07, 255.61],
-          "alpha": 1,
+          "components": [0.2088, 0.0702, 255.56],
+          "alpha": 1.0,
           "hex": "#001737"
         }
       },
@@ -440,36 +1457,117 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6499, 0.1912, 253.52],
-          "alpha": 0.08,
-          "hex": "#1E8FFF14"
+          "components": [0.6141, 0.2115, 256.22],
+          "alpha": 0.0706,
+          "hex": "#007FFF12"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6152, 0.2108, 256.1],
-          "alpha": 0.11,
-          "hex": "#0080FF1C"
+          "components": [0.6141, 0.2115, 256.22],
+          "alpha": 0.1098,
+          "hex": "#007FFF1C"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6225, 0.2064, 255.9],
-          "alpha": 0.17,
-          "hex": "#0E83FF2B"
+          "components": [0.6077, 0.215, 256.92],
+          "alpha": 0.1608,
+          "hex": "#007CFF29"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6048, 0.2166, 257.21],
-          "alpha": 0.31,
+          "components": [0.6041, 0.217, 257.29],
+          "alpha": 0.3098,
           "hex": "#007BFF4F"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5987, 0.2201, 257.84],
+          "alpha": 0.4667,
+          "hex": "#0078FF77"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5829, 0.2292, 259.29],
+          "alpha": 0.651,
+          "hex": "#0070FFA6"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5995, 0.2046, 255.99],
+          "alpha": 0.99,
+          "hex": "#007CF6FC"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.516, 0.1795, 256.49],
+          "alpha": 0.99,
+          "hex": "#0063CBFC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4614, 0.1572, 255.94],
+          "alpha": 0.99,
+          "hex": "#0055ADFC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.349, 0.1369, 259.24],
+          "alpha": 0.9333,
+          "hex": "#003480EE"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2708, 0.1133, 260.46],
+          "alpha": 0.9412,
+          "hex": "#00215CF0"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2365, 0.0763, 254.42],
+          "alpha": 0.99,
+          "hex": "#001E41FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2004, 0.0704, 256.74],
+          "alpha": 0.99,
+          "hex": "#001535FC"
         }
       }
     },
@@ -479,8 +1577,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9837, 0.0085, 44.54],
-          "alpha": 1,
-          "hex": "#fff8f5"
+          "alpha": 1.0,
+          "hex": "#FFF8F5"
         }
       },
       "50": {
@@ -488,8 +1586,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9659, 0.0171, 35.14],
-          "alpha": 1,
-          "hex": "#fff0ec"
+          "alpha": 1.0,
+          "hex": "#FFF0EC"
         }
       },
       "100": {
@@ -497,8 +1595,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9344, 0.0339, 35.8],
-          "alpha": 1,
-          "hex": "#ffe2da"
+          "alpha": 1.0,
+          "hex": "#FFE2DA"
         }
       },
       "200": {
@@ -506,8 +1604,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8476, 0.0856, 37.59],
-          "alpha": 1,
-          "hex": "#ffbaa5"
+          "alpha": 1.0,
+          "hex": "#FFBAA5"
         }
       },
       "300": {
@@ -515,8 +1613,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7671, 0.1418, 38.37],
-          "alpha": 1,
-          "hex": "#ff916e"
+          "alpha": 1.0,
+          "hex": "#FF916E"
         }
       },
       "400": {
@@ -524,8 +1622,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7279, 0.1703, 38.58],
-          "alpha": 1,
-          "hex": "#fe7b50",
+          "alpha": 1.0,
+          "hex": "#FE7B50",
           "description": "Brand anchor: Rubberband"
         }
       },
@@ -534,8 +1632,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6779, 0.2096, 40.36],
-          "alpha": 1,
-          "hex": "#fc5b05",
+          "alpha": 1.0,
+          "hex": "#FC5B05",
           "description": "Brand anchor: Thumbtack"
         }
       },
@@ -544,8 +1642,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5394, 0.1828, 36.43],
-          "alpha": 1,
-          "hex": "#c13600"
+          "alpha": 1.0,
+          "hex": "#C13600"
         }
       },
       "700": {
@@ -553,16 +1651,16 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4616, 0.1629, 34.74],
-          "alpha": 1,
-          "hex": "#9f2500"
+          "alpha": 1.0,
+          "hex": "#9F2500"
         }
       },
       "800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.393, 0.143, 33.49],
-          "alpha": 1,
+          "components": [0.3926, 0.143, 33.5],
+          "alpha": 1.0,
           "hex": "#811800"
         }
       },
@@ -571,17 +1669,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3043, 0.1137, 32.49],
-          "alpha": 1,
-          "hex": "#5b0b00"
+          "alpha": 1.0,
+          "hex": "#5B0B00"
         }
       },
       "950": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.236, 0.0899, 31.8],
-          "alpha": 1,
-          "hex": "#3f0400"
+          "components": [0.2359, 0.0901, 31.71],
+          "alpha": 1.0,
+          "hex": "#3F0400"
         }
       },
       "975": {
@@ -589,7 +1687,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2114, 0.07, 29.72],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#320704"
         }
       },
@@ -597,36 +1695,117 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6708, 0.221, 37.37],
-          "alpha": 0.04,
-          "hex": "#FF50050A"
+          "components": [0.6672, 0.2239, 36.87],
+          "alpha": 0.0392,
+          "hex": "#FF4D000A"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6598, 0.229, 34.15],
-          "alpha": 0.08,
-          "hex": "#FF441214"
+          "components": [0.6482, 0.2393, 32.96],
+          "alpha": 0.0745,
+          "hex": "#FF360013"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6545, 0.2337, 33.76],
-          "alpha": 0.15,
-          "hex": "#FF3E0826"
+          "components": [0.6492, 0.2384, 33.16],
+          "alpha": 0.1451,
+          "hex": "#FF370025"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6552, 0.2332, 34.09],
-          "alpha": 0.36,
-          "hex": "#FF3F055C"
+          "components": [0.6524, 0.2357, 33.8],
+          "alpha": 0.3529,
+          "hex": "#FF3C005A"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.654, 0.2344, 34.12],
+          "alpha": 0.5686,
+          "hex": "#FF3E0091"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6524, 0.2324, 34.36],
+          "alpha": 0.6863,
+          "hex": "#FE3F00AF"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.674, 0.2125, 39.77],
+          "alpha": 0.9804,
+          "hex": "#FC5800FA"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5363, 0.1838, 35.96],
+          "alpha": 0.99,
+          "hex": "#C03400FC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4578, 0.1636, 34.24],
+          "alpha": 0.99,
+          "hex": "#9E2300FC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3882, 0.1433, 32.96],
+          "alpha": 0.99,
+          "hex": "#801600FC"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2988, 0.1137, 31.84],
+          "alpha": 0.99,
+          "hex": "#590900FC"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2282, 0.091, 30.18],
+          "alpha": 0.99,
+          "hex": "#3D0100FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1965, 0.0733, 32.59],
+          "alpha": 0.9843,
+          "hex": "#2F0300FB"
         }
       }
     },
@@ -636,8 +1815,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9824, 0.0282, 148.77],
-          "alpha": 1,
-          "hex": "#edffef"
+          "alpha": 1.0,
+          "hex": "#EDFFEF"
         }
       },
       "50": {
@@ -645,8 +1824,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9655, 0.0561, 149.93],
-          "alpha": 1,
-          "hex": "#daffe0"
+          "alpha": 1.0,
+          "hex": "#DAFFE0"
         }
       },
       "100": {
@@ -654,8 +1833,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9278, 0.1024, 149.88],
-          "alpha": 1,
-          "hex": "#b6fbc3"
+          "alpha": 1.0,
+          "hex": "#B6FBC3"
         }
       },
       "200": {
@@ -663,8 +1842,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8506, 0.1804, 149.93],
-          "alpha": 1,
-          "hex": "#67ee8c"
+          "alpha": 1.0,
+          "hex": "#67EE8C"
         }
       },
       "300": {
@@ -672,17 +1851,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7817, 0.1928, 150.67],
-          "alpha": 1,
-          "hex": "#39d973"
+          "alpha": 1.0,
+          "hex": "#39D973"
         }
       },
       "400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.702, 0.1952, 148.39],
-          "alpha": 1,
-          "hex": "#19be52"
+          "components": [0.7014, 0.1953, 148.35],
+          "alpha": 1.0,
+          "hex": "#19BE52"
         }
       },
       "500": {
@@ -690,8 +1869,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6362, 0.1974, 145.47],
-          "alpha": 1,
-          "hex": "#00a831"
+          "alpha": 1.0,
+          "hex": "#00A831"
         }
       },
       "600": {
@@ -699,8 +1878,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5069, 0.1569, 145.56],
-          "alpha": 1,
-          "hex": "#007b22"
+          "alpha": 1.0,
+          "hex": "#007B22"
         }
       },
       "700": {
@@ -708,7 +1887,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4463, 0.1422, 144.58],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#006715"
         }
       },
@@ -716,9 +1895,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.3955, 0.1156, 147.66],
-          "alpha": 1,
-          "hex": "#00561d"
+          "components": [0.395, 0.1155, 147.62],
+          "alpha": 1.0,
+          "hex": "#00561D"
         }
       },
       "900": {
@@ -726,8 +1905,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3197, 0.0997, 145.3],
-          "alpha": 1,
-          "hex": "#003f0c"
+          "alpha": 1.0,
+          "hex": "#003F0C"
         }
       },
       "950": {
@@ -735,8 +1914,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2548, 0.0796, 145.23],
-          "alpha": 1,
-          "hex": "#002c06"
+          "alpha": 1.0,
+          "hex": "#002C06"
         }
       },
       "975": {
@@ -744,7 +1923,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2118, 0.0653, 145.69],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#002004"
         }
       },
@@ -752,36 +1931,117 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8695, 0.2801, 143.52],
-          "alpha": 0.08,
-          "hex": "#1EFF3714"
+          "components": [0.8669, 0.2908, 142.94],
+          "alpha": 0.0706,
+          "hex": "#00FF1D12"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8685, 0.2814, 143.77],
-          "alpha": 0.15,
-          "hex": "#0FFF3726"
+          "components": [0.8673, 0.2872, 143.34],
+          "alpha": 0.1451,
+          "hex": "#00FF2A25"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8316, 0.2716, 143.71],
-          "alpha": 0.29,
-          "hex": "#03F1304A"
+          "components": [0.8314, 0.2728, 143.63],
+          "alpha": 0.2863,
+          "hex": "#00F12E49"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.796, 0.2508, 144.9],
-          "alpha": 0.6,
-          "hex": "#02E33F99"
+          "components": [0.7945, 0.2509, 144.88],
+          "alpha": 0.5961,
+          "hex": "#00E33E98"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7417, 0.2215, 146.85],
+          "alpha": 0.7765,
+          "hex": "#00CE4BC6"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6785, 0.2042, 146.55],
+          "alpha": 0.902,
+          "hex": "#00B73FE6"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6336, 0.1978, 145.27],
+          "alpha": 0.99,
+          "hex": "#00A72FFC"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5028, 0.1569, 145.29],
+          "alpha": 0.99,
+          "hex": "#007A20FC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4415, 0.1418, 144.31],
+          "alpha": 0.99,
+          "hex": "#006513FC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3894, 0.1153, 147.16],
+          "alpha": 0.99,
+          "hex": "#00541BFC"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.313, 0.099, 144.83],
+          "alpha": 0.99,
+          "hex": "#003D0AFC"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.247, 0.0796, 144.22],
+          "alpha": 0.99,
+          "hex": "#002A03FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.203, 0.0663, 143.8],
+          "alpha": 0.99,
+          "hex": "#001E01FC"
         }
       }
     },
@@ -790,9 +2050,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.9703, 0.0147, 286],
-          "alpha": 1,
-          "hex": "#f4f4ff"
+          "components": [0.9703, 0.0147, 286.0],
+          "alpha": 1.0,
+          "hex": "#F4F4FF"
         }
       },
       "50": {
@@ -800,8 +2060,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9499, 0.0243, 280.81],
-          "alpha": 1,
-          "hex": "#ebedff"
+          "alpha": 1.0,
+          "hex": "#EBEDFF"
         }
       },
       "100": {
@@ -809,8 +2069,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9201, 0.0395, 282.43],
-          "alpha": 1,
-          "hex": "#e0e2ff"
+          "alpha": 1.0,
+          "hex": "#E0E2FF"
         }
       },
       "200": {
@@ -818,35 +2078,35 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8503, 0.0754, 280.52],
-          "alpha": 1,
-          "hex": "#c4c9ff"
+          "alpha": 1.0,
+          "hex": "#C4C9FF"
         }
       },
       "300": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7625, 0.1242, 281],
-          "alpha": 1,
-          "hex": "#a4a8ff"
+          "components": [0.7625, 0.1242, 281.0],
+          "alpha": 1.0,
+          "hex": "#A4A8FF"
         }
       },
       "400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.712, 0.1531, 280.1],
-          "alpha": 1,
-          "hex": "#9195ff"
+          "components": [0.7124, 0.1529, 280.13],
+          "alpha": 1.0,
+          "hex": "#9195FF"
         }
       },
       "500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.615, 0.2131, 280.7],
-          "alpha": 1,
-          "hex": "#736bff"
+          "components": [0.6155, 0.2129, 280.54],
+          "alpha": 1.0,
+          "hex": "#736BFF"
         }
       },
       "600": {
@@ -854,34 +2114,34 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5289, 0.2241, 281.65],
-          "alpha": 1,
-          "hex": "#5f4ae6"
+          "alpha": 1.0,
+          "hex": "#5F4AE6"
         }
       },
       "700": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.466, 0.1961, 280.9],
-          "alpha": 1,
-          "hex": "#4e3ec2"
+          "components": [0.4662, 0.1962, 281.1],
+          "alpha": 1.0,
+          "hex": "#4E3EC2"
         }
       },
       "800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.379, 0.1771, 278.1],
-          "alpha": 1,
-          "hex": "#34299c"
+          "components": [0.3787, 0.1768, 278.07],
+          "alpha": 1.0,
+          "hex": "#34299C"
         }
       },
       "900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.317, 0.142, 278.2],
-          "alpha": 1,
+          "components": [0.317, 0.1416, 278.19],
+          "alpha": 1.0,
           "hex": "#272077"
         }
       },
@@ -890,7 +2150,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2448, 0.1108, 277.85],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#181353"
         }
       },
@@ -899,44 +2159,125 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.1951, 0.0693, 277.85],
-          "alpha": 1,
-          "hex": "#0f0f33"
+          "alpha": 1.0,
+          "hex": "#0F0F33"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.4762, 0.2966, 267.42],
-          "alpha": 0.05,
-          "hex": "#2323FF0D"
+          "components": [0.452, 0.3133, 264.06],
+          "alpha": 0.0431,
+          "hex": "#0000FF0B"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.4661, 0.3036, 264.5],
-          "alpha": 0.08,
-          "hex": "#051EFF14"
+          "components": [0.4624, 0.3062, 264.19],
+          "alpha": 0.0784,
+          "hex": "#0019FF14"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.4693, 0.3013, 265.31],
-          "alpha": 0.13,
-          "hex": "#1120FF21"
+          "components": [0.4576, 0.3094, 264.14],
+          "alpha": 0.1216,
+          "hex": "#0010FF1F"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.4666, 0.3032, 264.75],
-          "alpha": 0.24,
-          "hex": "#091EFF3D"
+          "components": [0.4602, 0.3077, 264.17],
+          "alpha": 0.2314,
+          "hex": "#0015FF3B"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4556, 0.3108, 264.11],
+          "alpha": 0.3569,
+          "hex": "#000BFF5B"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.455, 0.3113, 264.11],
+          "alpha": 0.4314,
+          "hex": "#0009FF6E"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4539, 0.3118, 264.99],
+          "alpha": 0.5804,
+          "hex": "#0E00FF94"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4111, 0.275, 267.75],
+          "alpha": 0.7098,
+          "hex": "#1E00DCB5"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3459, 0.2314, 267.76],
+          "alpha": 0.7569,
+          "hex": "#1500AEC1"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2894, 0.1942, 267.45],
+          "alpha": 0.8392,
+          "hex": "#0D0089D6"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2309, 0.1541, 268.05],
+          "alpha": 0.8745,
+          "hex": "#080064DF"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1814, 0.1194, 269.62],
+          "alpha": 0.9255,
+          "hex": "#050045EC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1219, 0.0845, 264.06],
+          "alpha": 0.9412,
+          "hex": "#000026F0"
         }
       }
     },
@@ -945,9 +2286,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.9782, 0.0191, 325.55],
-          "alpha": 1,
-          "hex": "#fff4ff"
+          "components": [0.9788, 0.0186, 325.49],
+          "alpha": 1.0,
+          "hex": "#FFF4FF"
         }
       },
       "50": {
@@ -955,8 +2296,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9637, 0.0322, 325.69],
-          "alpha": 1,
-          "hex": "#ffecff"
+          "alpha": 1.0,
+          "hex": "#FFECFF"
         }
       },
       "100": {
@@ -964,8 +2305,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9253, 0.0627, 329.34],
-          "alpha": 1,
-          "hex": "#ffd8fb"
+          "alpha": 1.0,
+          "hex": "#FFD8FB"
         }
       },
       "200": {
@@ -973,8 +2314,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.887, 0.1029, 327.44],
-          "alpha": 1,
-          "hex": "#ffc2fd",
+          "alpha": 1.0,
+          "hex": "#FFC2FD",
           "description": "Brand anchor: Eraser"
         }
       },
@@ -982,18 +2323,18 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.807, 0.166, 333.78],
-          "alpha": 1,
-          "hex": "#ff94ec"
+          "components": [0.8067, 0.1664, 333.84],
+          "alpha": 1.0,
+          "hex": "#FF94EC"
         }
       },
       "400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.737, 0.198, 341.58],
-          "alpha": 1,
-          "hex": "#f96fcd"
+          "components": [0.7366, 0.1977, 341.56],
+          "alpha": 1.0,
+          "hex": "#F96FCD"
         }
       },
       "500": {
@@ -1001,17 +2342,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6557, 0.2007, 346.62],
-          "alpha": 1,
-          "hex": "#e251a9"
+          "alpha": 1.0,
+          "hex": "#E251A9"
         }
       },
       "600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.534, 0.183, 344.19],
-          "alpha": 1,
-          "hex": "#b03286"
+          "components": [0.5338, 0.1829, 344.19],
+          "alpha": 1.0,
+          "hex": "#B03286"
         }
       },
       "700": {
@@ -1019,8 +2360,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4641, 0.1602, 344.45],
-          "alpha": 1,
-          "hex": "#92276e"
+          "alpha": 1.0,
+          "hex": "#92276E"
         }
       },
       "800": {
@@ -1028,7 +2369,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4011, 0.1269, 344.4],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#742458"
         }
       },
@@ -1036,9 +2377,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.297, 0.095, 343.19],
-          "alpha": 1,
-          "hex": "#4b1439"
+          "components": [0.2966, 0.095, 343.2],
+          "alpha": 1.0,
+          "hex": "#4B1439"
         }
       },
       "950": {
@@ -1046,7 +2387,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2332, 0.0908, 343.78],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#380428"
         }
       },
@@ -1055,308 +2396,125 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2016, 0.0706, 345.97],
-          "alpha": 1,
-          "hex": "#2b051d"
+          "alpha": 1.0,
+          "hex": "#2B051D"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7091, 0.3124, 328.27],
-          "alpha": 0.05,
-          "hex": "#FF23FF0D"
+          "components": [0.7017, 0.3225, 328.36],
+          "alpha": 0.0431,
+          "hex": "#FF00FF0B"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7044, 0.3188, 328.33],
-          "alpha": 0.08,
-          "hex": "#FF12FF14"
+          "components": [0.7017, 0.3225, 328.36],
+          "alpha": 0.0745,
+          "hex": "#FF00FF13"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6892, 0.3052, 333.97],
-          "alpha": 0.16,
-          "hex": "#FF0BE629"
+          "components": [0.687, 0.3067, 334.22],
+          "alpha": 0.1529,
+          "hex": "#FF00E527"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6972, 0.3174, 330.1],
-          "alpha": 0.24,
-          "hex": "#FF01F73D"
-        }
-      }
-    },
-    "neutral": {
-      "0": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 1,
-          "hex": "#ffffff",
-          "description": "Brand anchor: Paper"
-        }
-      },
-      "25": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9851, 0, 0],
-          "alpha": 1,
-          "hex": "#fafafa"
-        }
-      },
-      "50": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9702, 0, 0],
-          "alpha": 1,
-          "hex": "#f5f5f5"
-        }
-      },
-      "100": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9431, 0, 0],
-          "alpha": 1,
-          "hex": "#ececec"
-        }
-      },
-      "200": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.8699, 0, 0],
-          "alpha": 1,
-          "hex": "#d4d4d4"
-        }
-      },
-      "300": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.8015, 0, 0],
-          "alpha": 1,
-          "hex": "#bebebe"
-        }
-      },
-      "400": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.72, 0, 0],
-          "alpha": 1,
-          "hex": "#a4a4a4"
-        }
-      },
-      "500": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.6234, 0, 0],
-          "alpha": 1,
-          "hex": "#878787"
-        }
-      },
-      "600": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.5103, 0, 0],
-          "alpha": 1,
-          "hex": "#666666"
-        }
-      },
-      "700": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.4494, 0, 0],
-          "alpha": 1,
-          "hex": "#555555"
-        }
-      },
-      "800": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.3523, 0, 0],
-          "alpha": 1,
-          "hex": "#3b3b3b"
-        }
-      },
-      "900": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.2891, 0, 0],
-          "alpha": 1,
-          "hex": "#2b2b2b"
-        }
-      },
-      "950": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.2308, 0, 0],
-          "alpha": 1,
-          "hex": "#1d1d1d"
-        }
-      },
-      "975": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.1591, 0, 0],
-          "alpha": 1,
-          "hex": "#0d0d0d"
-        }
-      },
-      "1000": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0, 0, 0],
-          "alpha": 1,
-          "hex": "#000000"
-        }
-      },
-      "A0": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0, 0, 0],
-          "alpha": 0.0,
-          "hex": "#00000000"
-        }
-      },
-      "A25": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.1149, 0, 0],
-          "alpha": 0.02,
-          "hex": "#05050505"
-        }
-      },
-      "A50": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.1149, 0, 0],
-          "alpha": 0.04,
-          "hex": "#0505050A"
-        }
-      },
-      "A100": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.1822, 0, 0],
-          "alpha": 0.08,
-          "hex": "#12121214"
-        }
-      },
-      "A200": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.0847, 0, 0],
-          "alpha": 0.17,
-          "hex": "#0202022B"
+          "components": [0.6968, 0.3174, 330.17],
+          "alpha": 0.2392,
+          "hex": "#FF00F73D"
         }
       },
       "A300": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1149, 0, 0],
-          "alpha": 0.26,
-          "hex": "#05050542"
+          "components": [0.6773, 0.2957, 338.89],
+          "alpha": 0.4196,
+          "hex": "#FF00D26B"
         }
       },
       "A400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.0847, 0, 0],
-          "alpha": 0.36,
-          "hex": "#0202025C"
+          "components": [0.6403, 0.2685, 348.58],
+          "alpha": 0.5647,
+          "hex": "#F400A690"
         }
       },
       "A500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1149, 0, 0],
-          "alpha": 0.48,
-          "hex": "#0505057A"
+          "components": [0.5702, 0.2349, 353.9],
+          "alpha": 0.6824,
+          "hex": "#D40081AE"
         }
       },
       "A600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0, 0, 0],
-          "alpha": 0.6,
-          "hex": "#00000099"
+          "components": [0.4593, 0.1924, 348.92],
+          "alpha": 0.8039,
+          "hex": "#9D0069CD"
         }
       },
       "A700": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.0672, 0, 0],
-          "alpha": 0.67,
-          "hex": "#010101AB"
+          "components": [0.3928, 0.1647, 348.68],
+          "alpha": 0.8471,
+          "hex": "#7E0054D8"
         }
       },
       "A800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0, 0, 0],
-          "alpha": 0.77,
-          "hex": "#000000C4"
+          "components": [0.3165, 0.1326, 348.78],
+          "alpha": 0.8588,
+          "hex": "#5D003DDB"
         }
       },
       "A900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.0969, 0, 0],
-          "alpha": 0.84,
-          "hex": "#030303D6"
+          "components": [0.2362, 0.1001, 345.8],
+          "alpha": 0.9216,
+          "hex": "#3C0028EB"
         }
       },
       "A950": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.0672, 0, 0],
-          "alpha": 0.89,
-          "hex": "#010101E3"
+          "components": [0.2193, 0.0935, 344.18],
+          "alpha": 0.9843,
+          "hex": "#350025FB"
         }
       },
       "A975": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0, 0, 0],
-          "alpha": 0.95,
-          "hex": "#000000F2"
+          "components": [0.1806, 0.0764, 346.22],
+          "alpha": 0.9804,
+          "hex": "#270018FA"
         }
       }
     },
@@ -1366,8 +2524,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9673, 0.0205, 67.52],
-          "alpha": 1,
-          "hex": "#fef2e6"
+          "alpha": 1.0,
+          "hex": "#FEF2E6"
         }
       },
       "50": {
@@ -1375,8 +2533,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9523, 0.0366, 72.6],
-          "alpha": 1,
-          "hex": "#ffecd5"
+          "alpha": 1.0,
+          "hex": "#FFECD5"
         }
       },
       "100": {
@@ -1384,8 +2542,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9243, 0.0542, 67.95],
-          "alpha": 1,
-          "hex": "#ffe0c0"
+          "alpha": 1.0,
+          "hex": "#FFE0C0"
         }
       },
       "200": {
@@ -1393,8 +2551,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8606, 0.1002, 65.34],
-          "alpha": 1,
-          "hex": "#ffc48a"
+          "alpha": 1.0,
+          "hex": "#FFC48A"
         }
       },
       "300": {
@@ -1402,8 +2560,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7839, 0.1608, 63.57],
-          "alpha": 1,
-          "hex": "#ff9f33"
+          "alpha": 1.0,
+          "hex": "#FF9F33"
         }
       },
       "400": {
@@ -1411,8 +2569,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7261, 0.1852, 52.58],
-          "alpha": 1,
-          "hex": "#fd7e00",
+          "alpha": 1.0,
+          "hex": "#FD7E00",
           "description": "Brand anchor: Happyhour"
         }
       },
@@ -1421,17 +2579,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6617, 0.1893, 44.93],
-          "alpha": 1,
-          "hex": "#ec6200"
+          "alpha": 1.0,
+          "hex": "#EC6200"
         }
       },
       "600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.53, 0.165, 40.39],
-          "alpha": 1,
-          "hex": "#b63f00"
+          "components": [0.5305, 0.1648, 40.5],
+          "alpha": 1.0,
+          "hex": "#B63F00"
         }
       },
       "700": {
@@ -1439,8 +2597,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4689, 0.1456, 40.5],
-          "alpha": 1,
-          "hex": "#9a3400"
+          "alpha": 1.0,
+          "hex": "#9A3400"
         }
       },
       "800": {
@@ -1448,7 +2606,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4077, 0.1336, 37.92],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#822500"
         }
       },
@@ -1457,8 +2615,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3243, 0.1084, 37.05],
-          "alpha": 1,
-          "hex": "#5f1700"
+          "alpha": 1.0,
+          "hex": "#5F1700"
         }
       },
       "950": {
@@ -1466,8 +2624,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2421, 0.082, 36.47],
-          "alpha": 1,
-          "hex": "#3e0b00"
+          "alpha": 1.0,
+          "hex": "#3E0B00"
         }
       },
       "975": {
@@ -1475,7 +2633,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2121, 0.0706, 37.19],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#320800"
         }
       },
@@ -1483,36 +2641,117 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7136, 0.1784, 53.73],
-          "alpha": 0.1,
-          "hex": "#F57D051A"
+          "components": [0.7093, 0.1802, 52.88],
+          "alpha": 0.098,
+          "hex": "#F57A0019"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7555, 0.1769, 59.35],
-          "alpha": 0.17,
-          "hex": "#FF8F082B"
+          "components": [0.75, 0.1792, 58.11],
+          "alpha": 0.1647,
+          "hex": "#FF8C012A"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7365, 0.1837, 54.12],
-          "alpha": 0.25,
-          "hex": "#FF830340"
+          "components": [0.7342, 0.1848, 53.62],
+          "alpha": 0.2471,
+          "hex": "#FF82003F"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7304, 0.1863, 52.52],
-          "alpha": 0.46,
-          "hex": "#FF7F0175"
+          "components": [0.7295, 0.1867, 52.32],
+          "alpha": 0.4588,
+          "hex": "#FF7E0075"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7427, 0.1817, 56.0],
+          "alpha": 0.8,
+          "hex": "#FF8700CC"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.7242, 0.186, 52.04],
+          "alpha": 0.99,
+          "hex": "#FD7D01FC"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.6593, 0.1904, 44.4],
+          "alpha": 0.99,
+          "hex": "#EC6000FC"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5269, 0.1656, 39.9],
+          "alpha": 0.99,
+          "hex": "#B53D00FC"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4646, 0.1463, 39.8],
+          "alpha": 0.99,
+          "hex": "#993200FC"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4028, 0.1342, 37.19],
+          "alpha": 0.99,
+          "hex": "#812300FC"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3184, 0.1087, 36.13],
+          "alpha": 0.99,
+          "hex": "#5D1500FC"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2349, 0.0821, 35.15],
+          "alpha": 0.99,
+          "hex": "#3C0900FC"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2035, 0.0712, 35.09],
+          "alpha": 0.99,
+          "hex": "#300600FC"
         }
       }
     },
@@ -1521,18 +2760,18 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.9776, 0.0147, 312],
-          "alpha": 1,
-          "hex": "#fbf5ff"
+          "components": [0.9776, 0.0147, 312.0],
+          "alpha": 1.0,
+          "hex": "#FBF5FF"
         }
       },
       "50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.951, 0.0321, 311.49],
-          "alpha": 1,
-          "hex": "#f6e9ff"
+          "components": [0.9507, 0.0323, 311.64],
+          "alpha": 1.0,
+          "hex": "#F6E9FF"
         }
       },
       "100": {
@@ -1540,8 +2779,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.909, 0.0637, 314.43],
-          "alpha": 1,
-          "hex": "#f1d5ff"
+          "alpha": 1.0,
+          "hex": "#F1D5FF"
         }
       },
       "200": {
@@ -1549,8 +2788,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8701, 0.0965, 316.6],
-          "alpha": 1,
-          "hex": "#eec1ff"
+          "alpha": 1.0,
+          "hex": "#EEC1FF"
         }
       },
       "300": {
@@ -1558,26 +2797,26 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8108, 0.1412, 315.48],
-          "alpha": 1,
-          "hex": "#e4a4ff"
+          "alpha": 1.0,
+          "hex": "#E4A4FF"
         }
       },
       "400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.734, 0.1621, 315.88],
-          "alpha": 1,
-          "hex": "#d086ed"
+          "components": [0.7338, 0.1623, 315.92],
+          "alpha": 1.0,
+          "hex": "#D086ED"
         }
       },
       "500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.628, 0.1681, 312.69],
-          "alpha": 1,
-          "hex": "#ab65d0",
+          "components": [0.6279, 0.1685, 312.7],
+          "alpha": 1.0,
+          "hex": "#AB65D0",
           "description": "Brand anchor: Smoothie"
         }
       },
@@ -1585,27 +2824,27 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.5177, 0.162, 313.92],
-          "alpha": 1,
-          "hex": "#8945a8"
+          "components": [0.5181, 0.1617, 313.88],
+          "alpha": 1.0,
+          "hex": "#8945A8"
         }
       },
       "700": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.476, 0.156, 313.2],
-          "alpha": 1,
-          "hex": "#7b3a99"
+          "components": [0.4759, 0.1567, 313.59],
+          "alpha": 1.0,
+          "hex": "#7B3A99"
         }
       },
       "800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.422, 0.136, 315.49],
-          "alpha": 1,
-          "hex": "#69307f"
+          "components": [0.4218, 0.1364, 315.46],
+          "alpha": 1.0,
+          "hex": "#69307F"
         }
       },
       "900": {
@@ -1613,8 +2852,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3143, 0.0996, 313.76],
-          "alpha": 1,
-          "hex": "#431e54"
+          "alpha": 1.0,
+          "hex": "#431E54"
         }
       },
       "950": {
@@ -1622,53 +2861,134 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2351, 0.0734, 313.34],
-          "alpha": 1,
-          "hex": "#2a1136"
+          "alpha": 1.0,
+          "hex": "#2A1136"
         }
       },
       "975": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.194, 0.062, 312.79],
-          "alpha": 1,
-          "hex": "#1e0a28"
+          "components": [0.1937, 0.062, 312.81],
+          "alpha": 1.0,
+          "hex": "#1E0A28"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.5632, 0.2948, 302.45],
-          "alpha": 0.04,
-          "hex": "#9B05FF0A"
+          "components": [0.5597, 0.2957, 301.91],
+          "alpha": 0.0392,
+          "hex": "#9900FF0A"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.5645, 0.2935, 302.36],
-          "alpha": 0.09,
-          "hex": "#9B0BFF17"
+          "components": [0.5569, 0.2954, 301.19],
+          "alpha": 0.0863,
+          "hex": "#9700FF16"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.5867, 0.2975, 307.8],
-          "alpha": 0.17,
-          "hex": "#AD08FF2B"
+          "components": [0.5812, 0.2987, 307.02],
+          "alpha": 0.1647,
+          "hex": "#AA00FF2A"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6051, 0.3009, 311.78],
-          "alpha": 0.25,
-          "hex": "#BB07FF40"
+          "components": [0.6012, 0.302, 311.32],
+          "alpha": 0.2431,
+          "hex": "#B900FF3E"
+        }
+      },
+      "A300": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5935, 0.3007, 309.71],
+          "alpha": 0.3569,
+          "hex": "#B300FF5B"
+        }
+      },
+      "A400": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.5309, 0.2672, 310.98],
+          "alpha": 0.4745,
+          "hex": "#9C00D979"
+        }
+      },
+      "A500": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.4411, 0.2271, 306.67],
+          "alpha": 0.6039,
+          "hex": "#7400B19A"
+        }
+      },
+      "A600": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3709, 0.1881, 309.52],
+          "alpha": 0.7294,
+          "hex": "#5D0088BA"
+        }
+      },
+      "A700": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.3455, 0.1752, 309.54],
+          "alpha": 0.7725,
+          "hex": "#54007BC5"
+        }
+      },
+      "A800": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2998, 0.1497, 312.54],
+          "alpha": 0.8118,
+          "hex": "#460061CF"
+        }
+      },
+      "A900": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.2174, 0.1091, 311.6],
+          "alpha": 0.8824,
+          "hex": "#2A003DE1"
+        }
+      },
+      "A950": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1676, 0.0835, 312.82],
+          "alpha": 0.9333,
+          "hex": "#1B0028EE"
+        }
+      },
+      "A975": {
+        "type": "color",
+        "value": {
+          "colorSpace": "oklch",
+          "components": [0.1471, 0.073, 313.51],
+          "alpha": 0.9608,
+          "hex": "#15001FF5"
         }
       }
     },
@@ -1677,9 +2997,9 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.9667, 0.0163, 21.82],
-          "alpha": 1,
-          "hex": "#fff0ef"
+          "components": [0.9776, 0.0108, 23.94],
+          "alpha": 1.0,
+          "hex": "#FFF5F4"
         }
       },
       "50": {
@@ -1687,8 +3007,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9533, 0.0231, 23.95],
-          "alpha": 1,
-          "hex": "#ffeae8"
+          "alpha": 1.0,
+          "hex": "#FFEAE8"
         }
       },
       "100": {
@@ -1696,8 +3016,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9225, 0.0394, 25.51],
-          "alpha": 1,
-          "hex": "#ffdcd8"
+          "alpha": 1.0,
+          "hex": "#FFDCD8"
         }
       },
       "200": {
@@ -1705,8 +3025,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8339, 0.092, 28.19],
-          "alpha": 1,
-          "hex": "#ffb2a7"
+          "alpha": 1.0,
+          "hex": "#FFB2A7"
         }
       },
       "300": {
@@ -1714,8 +3034,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7533, 0.1484, 28.45],
-          "alpha": 1,
-          "hex": "#ff8778"
+          "alpha": 1.0,
+          "hex": "#FF8778"
         }
       },
       "400": {
@@ -1723,17 +3043,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6857, 0.2037, 29.76],
-          "alpha": 1,
-          "hex": "#ff5a47"
+          "alpha": 1.0,
+          "hex": "#FF5A47"
         }
       },
       "500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6495, 0.2369, 30.04],
-          "alpha": 1,
-          "hex": "#ff3623"
+          "components": [0.6497, 0.2368, 30.05],
+          "alpha": 1.0,
+          "hex": "#FF3623"
         }
       },
       "600": {
@@ -1741,8 +3061,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5342, 0.2172, 29.53],
-          "alpha": 1,
-          "hex": "#cd0600"
+          "alpha": 1.0,
+          "hex": "#CD0600"
         }
       },
       "700": {
@@ -1750,8 +3070,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4517, 0.1847, 28.2],
-          "alpha": 1,
-          "hex": "#a40007"
+          "alpha": 1.0,
+          "hex": "#A40007"
         }
       },
       "800": {
@@ -1759,16 +3079,16 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3712, 0.1509, 26.08],
-          "alpha": 1,
-          "hex": "#7d000c"
+          "alpha": 1.0,
+          "hex": "#7D000C"
         }
       },
       "900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.291, 0.118, 25.59],
-          "alpha": 1,
+          "components": [0.2899, 0.1176, 25.44],
+          "alpha": 1.0,
           "hex": "#580007"
         }
       },
@@ -1777,8 +3097,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2318, 0.0937, 24.02],
-          "alpha": 1,
-          "hex": "#3f0005"
+          "alpha": 1.0,
+          "hex": "#3F0005"
         }
       },
       "975": {
@@ -1786,280 +3106,125 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.1988, 0.0718, 20.63],
-          "alpha": 1,
-          "hex": "#2f0307"
+          "alpha": 1.0,
+          "hex": "#2F0307"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6289, 0.2567, 29.11],
-          "alpha": 0.04,
-          "hex": "#FF05050A"
+          "components": [0.6329, 0.253, 30.1],
+          "alpha": 0.0431,
+          "hex": "#FF17000B"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6434, 0.2428, 30.17],
-          "alpha": 0.1,
-          "hex": "#FF2D191A"
+          "components": [0.6326, 0.2533, 30.04],
+          "alpha": 0.0902,
+          "hex": "#FF160017"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6382, 0.248, 30.42],
-          "alpha": 0.16,
-          "hex": "#FF240B29"
+          "components": [0.6339, 0.2521, 30.28],
+          "alpha": 0.1529,
+          "hex": "#FF1A0027"
         }
       },
       "A200": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.6375, 0.2487, 30.71],
-          "alpha": 0.35,
-          "hex": "#FF230459"
-        }
-      }
-    },
-    "slate": {
-      "25": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9846, 0.0018, 248.57],
-          "alpha": 1,
-          "hex": "#f9fafb"
-        }
-      },
-      "50": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9692, 0.0035, 248.23],
-          "alpha": 1,
-          "hex": "#f3f5f7"
-        }
-      },
-      "100": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.9447, 0.0053, 248.12],
-          "alpha": 1,
-          "hex": "#eaedf0"
-        }
-      },
-      "200": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.917, 0.0081, 254],
-          "alpha": 1,
-          "hex": "#e0e4e9"
-        }
-      },
-      "300": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.856, 0.0111, 256.85],
-          "alpha": 1,
-          "hex": "#cbd0d7"
-        }
-      },
-      "400": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.754, 0.0181, 256.33],
-          "alpha": 1,
-          "hex": "#a8b0bb"
-        }
-      },
-      "500": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.629, 0.0281, 255.62],
-          "alpha": 1,
-          "hex": "#7e8a9a"
-        }
-      },
-      "600": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.5103, 0.0255, 256.8],
-          "alpha": 1,
-          "hex": "#5d6775"
-        }
-      },
-      "700": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.45, 0.022, 255.52],
-          "alpha": 1,
-          "hex": "#4d5662"
-        }
-      },
-      "800": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.3685, 0.0218, 256.4],
-          "alpha": 1,
-          "hex": "#38404b"
-        }
-      },
-      "900": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.278, 0.0156, 252.4],
-          "alpha": 1,
-          "hex": "#232930"
-        }
-      },
-      "950": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.2453, 0.0136, 253.1],
-          "alpha": 1,
-          "hex": "#1c2127"
-        }
-      },
-      "975": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.18, 0.008, 248.33],
-          "alpha": 1,
-          "hex": "#0f1215"
-        }
-      },
-      "A25": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.4688, 0.0781, 250.43],
-          "alpha": 0.03,
-          "hex": "#375D8508"
-        }
-      },
-      "A50": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.3343, 0.0951, 253.3],
-          "alpha": 0.05,
-          "hex": "#0837660D"
-        }
-      },
-      "A100": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.3337, 0.0688, 250.79],
-          "alpha": 0.09,
-          "hex": "#18385817"
-        }
-      },
-      "A200": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [0.3057, 0.079, 256.22],
-          "alpha": 0.13,
-          "hex": "#112F5621"
+          "components": [0.6361, 0.25, 30.68],
+          "alpha": 0.3451,
+          "hex": "#FF200058"
         }
       },
       "A300": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.2442, 0.0693, 257.66],
-          "alpha": 0.21,
-          "hex": "#081F4036"
+          "components": [0.6347, 0.2513, 30.42],
+          "alpha": 0.5294,
+          "hex": "#FF1C0087"
         }
       },
       "A400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.2333, 0.0665, 257.09],
-          "alpha": 0.35,
-          "hex": "#061D3C59"
+          "components": [0.634, 0.252, 30.29],
+          "alpha": 0.7216,
+          "hex": "#FF1A00B8"
         }
       },
       "A500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.2187, 0.0685, 255.77],
-          "alpha": 0.51,
-          "hex": "#021A3982"
+          "components": [0.6326, 0.2533, 30.04],
+          "alpha": 0.8627,
+          "hex": "#FF1600DC"
         }
       },
       "A600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1793, 0.0503, 254.55],
-          "alpha": 0.64,
-          "hex": "#021127A3"
+          "components": [0.5326, 0.2174, 29.4],
+          "alpha": 0.99,
+          "hex": "#CD0300FC"
         }
       },
       "A700": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1595, 0.0431, 250.87],
-          "alpha": 0.7,
-          "hex": "#010E1FB3"
+          "components": [0.4497, 0.1841, 28.55],
+          "alpha": 0.99,
+          "hex": "#A30005FC"
         }
       },
       "A800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.157, 0.0349, 253.16],
-          "alpha": 0.79,
-          "hex": "#030D1BC9"
+          "components": [0.3682, 0.1499, 26.67],
+          "alpha": 0.99,
+          "hex": "#7C000AFC"
         }
       },
       "A900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1351, 0.0244, 244.09],
-          "alpha": 0.87,
-          "hex": "#020911DE"
+          "components": [0.2858, 0.1164, 26.66],
+          "alpha": 0.99,
+          "hex": "#560004FC"
         }
       },
       "A950": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1312, 0.0198, 248.87],
-          "alpha": 0.9,
-          "hex": "#03080FE6"
+          "components": [0.2267, 0.0922, 26.4],
+          "alpha": 0.99,
+          "hex": "#3D0002FC"
         }
       },
       "A975": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.1168, 0.014, 231.47],
-          "alpha": 0.95,
-          "hex": "#020609F2"
+          "components": [0.1866, 0.0751, 21.36],
+          "alpha": 0.9882,
+          "hex": "#2D0004FC"
         }
       }
     },
@@ -2069,8 +3234,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9827, 0.021, 200.66],
-          "alpha": 1,
-          "hex": "#eafeff"
+          "alpha": 1.0,
+          "hex": "#EAFEFF"
         }
       },
       "50": {
@@ -2078,17 +3243,17 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.9575, 0.0424, 203.83],
-          "alpha": 1,
-          "hex": "#d1fafe"
+          "alpha": 1.0,
+          "hex": "#D1FAFE"
         }
       },
       "100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.935, 0.046, 205.09],
-          "alpha": 1,
-          "hex": "#c7f3f8"
+          "components": [0.9349, 0.0457, 204.99],
+          "alpha": 1.0,
+          "hex": "#C7F3F8"
         }
       },
       "200": {
@@ -2096,8 +3261,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.8766, 0.0677, 204.24],
-          "alpha": 1,
-          "hex": "#a1e4eb"
+          "alpha": 1.0,
+          "hex": "#A1E4EB"
         }
       },
       "300": {
@@ -2105,8 +3270,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7836, 0.0874, 204.93],
-          "alpha": 1,
-          "hex": "#6fc9d3",
+          "alpha": 1.0,
+          "hex": "#6FC9D3",
           "description": "Brand anchor: Tack"
         }
       },
@@ -2115,8 +3280,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.7154, 0.1006, 206.05],
-          "alpha": 1,
-          "hex": "#46b5c2"
+          "alpha": 1.0,
+          "hex": "#46B5C2"
         }
       },
       "500": {
@@ -2124,8 +3289,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.6385, 0.1093, 205.92],
-          "alpha": 1,
-          "hex": "#009eac"
+          "alpha": 1.0,
+          "hex": "#009EAC"
         }
       },
       "600": {
@@ -2133,7 +3298,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.5141, 0.0882, 207.28],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#007581"
         }
       },
@@ -2142,7 +3307,7 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.4634, 0.0796, 207.82],
-          "alpha": 1,
+          "alpha": 1.0,
           "hex": "#006570"
         }
       },
@@ -2151,8 +3316,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3982, 0.0687, 209.08],
-          "alpha": 1,
-          "hex": "#00515b"
+          "alpha": 1.0,
+          "hex": "#00515B"
         }
       },
       "900": {
@@ -2160,8 +3325,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.3052, 0.0529, 210.69],
-          "alpha": 1,
-          "hex": "#00363e"
+          "alpha": 1.0,
+          "hex": "#00363E"
         }
       },
       "950": {
@@ -2169,8 +3334,8 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2425, 0.042, 210.69],
-          "alpha": 1,
-          "hex": "#00252b"
+          "alpha": 1.0,
+          "hex": "#00252B"
         }
       },
       "975": {
@@ -2178,34 +3343,34 @@
         "value": {
           "colorSpace": "oklch",
           "components": [0.2037, 0.0354, 211.24],
-          "alpha": 1,
-          "hex": "#001b20"
+          "alpha": 1.0,
+          "hex": "#001B20"
         }
       },
       "A25": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8804, 0.1478, 200.72],
-          "alpha": 0.09,
-          "hex": "#16F4FF17"
+          "components": [0.8768, 0.1492, 201.29],
+          "alpha": 0.0824,
+          "hex": "#00F3FF15"
         }
       },
       "A50": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.8427, 0.1433, 206.66],
-          "alpha": 0.19,
-          "hex": "#0DE5FA30"
+          "components": [0.838, 0.1438, 207.32],
+          "alpha": 0.1804,
+          "hex": "#00E3FA2E"
         }
       },
       "A100": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7626, 0.1316, 209.35],
-          "alpha": 0.22,
+          "components": [0.7635, 0.1317, 209.21],
+          "alpha": 0.2196,
           "hex": "#00C8DF38"
         }
       },
@@ -2213,137 +3378,4654 @@
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [0.7101, 0.1219, 207.98],
-          "alpha": 0.37,
-          "hex": "#01B6C95E"
-        }
-      }
-    },
-    "white": {
-      "A0": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0,
-          "hex": "#FFFFFF00"
-        }
-      },
-      "A25": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.02,
-          "hex": "#FFFFFF05"
-        }
-      },
-      "A50": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.03,
-          "hex": "#FFFFFF08"
-        }
-      },
-      "A100": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.08,
-          "hex": "#FFFFFF14"
-        }
-      },
-      "A200": {
-        "type": "color",
-        "value": {
-          "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.16,
-          "hex": "#FFFFFF29"
+          "components": [0.7093, 0.122, 208.0],
+          "alpha": 0.3686,
+          "hex": "#00B6C95E"
         }
       },
       "A300": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.26,
-          "hex": "#FFFFFF42"
+          "components": [0.644, 0.111, 208.67],
+          "alpha": 0.5647,
+          "hex": "#009FB190"
         }
       },
       "A400": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.36,
-          "hex": "#FFFFFF5C"
+          "components": [0.6254, 0.108, 209.35],
+          "alpha": 0.7255,
+          "hex": "#0099ABB9"
         }
       },
       "A500": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.47,
-          "hex": "#FFFFFF78"
+          "components": [0.6357, 0.1088, 206.09],
+          "alpha": 0.99,
+          "hex": "#009DABFC"
         }
       },
       "A600": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.6,
-          "hex": "#FFFFFF99"
+          "components": [0.5098, 0.0876, 207.54],
+          "alpha": 0.99,
+          "hex": "#007480FC"
         }
       },
       "A700": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.67,
-          "hex": "#FFFFFFAB"
+          "components": [0.4585, 0.0789, 208.12],
+          "alpha": 0.99,
+          "hex": "#00636FFC"
         }
       },
       "A800": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.77,
-          "hex": "#FFFFFFC4"
+          "components": [0.3924, 0.0678, 209.48],
+          "alpha": 0.99,
+          "hex": "#004F59FC"
         }
       },
       "A900": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.83,
-          "hex": "#FFFFFFD4"
+          "components": [0.298, 0.0518, 211.31],
+          "alpha": 0.99,
+          "hex": "#00343CFC"
         }
       },
       "A950": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.89,
-          "hex": "#FFFFFFE3"
+          "components": [0.2342, 0.0407, 211.53],
+          "alpha": 0.99,
+          "hex": "#002329FC"
         }
       },
       "A975": {
         "type": "color",
         "value": {
           "colorSpace": "oklch",
-          "components": [1, 0, 0],
-          "alpha": 0.95,
-          "hex": "#FFFFFFF2"
+          "components": [0.1947, 0.034, 212.33],
+          "alpha": 0.99,
+          "hex": "#00191EFC"
+        }
+      }
+    },
+    "tenant": {
+      "airbnb": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9692, 0.0108, 9.91],
+            "alpha": 1.0,
+            "hex": "#FCF2F3"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9492, 0.0207, 17.32],
+            "alpha": 1.0,
+            "hex": "#FCE9E9"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9089, 0.0471, 16.35],
+            "alpha": 1.0,
+            "hex": "#FFD5D6"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8207, 0.0992, 16.3],
+            "alpha": 1.0,
+            "hex": "#FEAAAE"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7403, 0.1595, 16.58],
+            "alpha": 1.0,
+            "hex": "#FF7C87"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6595, 0.2294, 17.02],
+            "alpha": 1.0,
+            "hex": "#FF3A5D"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.589, 0.2297, 17.51],
+            "alpha": 1.0,
+            "hex": "#E51247"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4906, 0.1901, 17.9],
+            "alpha": 1.0,
+            "hex": "#B30E35"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4203, 0.1684, 18.25],
+            "alpha": 1.0,
+            "hex": "#930027"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3431, 0.1375, 18.88],
+            "alpha": 1.0,
+            "hex": "#6F001A"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2635, 0.1058, 20.2],
+            "alpha": 1.0,
+            "hex": "#4C000D"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2205, 0.0885, 19.95],
+            "alpha": 1.0,
+            "hex": "#3A0008"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2009, 0.0805, 18.66],
+            "alpha": 1.0,
+            "hex": "#320007"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5163, 0.2104, 27.04],
+            "alpha": 0.051,
+            "hex": "#C400140D"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5622, 0.2306, 29.23],
+            "alpha": 0.0863,
+            "hex": "#DC000016"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6281, 0.2574, 28.89],
+            "alpha": 0.1647,
+            "hex": "#FF00062A"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6227, 0.2549, 28.54],
+            "alpha": 0.3333,
+            "hex": "#FC000C55"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6286, 0.2568, 27.84],
+            "alpha": 0.5137,
+            "hex": "#FF001683"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6302, 0.2552, 24.65],
+            "alpha": 0.7725,
+            "hex": "#FF002DC5"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5792, 0.2327, 20.55],
+            "alpha": 0.9294,
+            "hex": "#E30039ED"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4759, 0.1913, 20.65],
+            "alpha": 0.9451,
+            "hex": "#AF0029F1"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4177, 0.1675, 19.03],
+            "alpha": 0.99,
+            "hex": "#920025FC"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3396, 0.1363, 19.88],
+            "alpha": 0.99,
+            "hex": "#6E0018FC"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2589, 0.1042, 21.54],
+            "alpha": 0.99,
+            "hex": "#4A000BFC"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2152, 0.0867, 22.19],
+            "alpha": 0.99,
+            "hex": "#380006FC"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1952, 0.0785, 21.58],
+            "alpha": 0.99,
+            "hex": "#300005FC"
+          }
+        }
+      },
+      "discord": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9796, 0.0096, 273.27],
+            "alpha": 1.0,
+            "hex": "#F6F8FF"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9592, 0.0193, 273.2],
+            "alpha": 1.0,
+            "hex": "#EDF1FF"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9096, 0.0406, 273.33],
+            "alpha": 1.0,
+            "hex": "#D8E0FD"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8296, 0.0848, 273.36],
+            "alpha": 1.0,
+            "hex": "#B5C4FF"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7397, 0.1309, 273.19],
+            "alpha": 1.0,
+            "hex": "#90A4FD"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.66, 0.1809, 273.12],
+            "alpha": 1.0,
+            "hex": "#7085FF"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5806, 0.209, 273.92],
+            "alpha": 1.0,
+            "hex": "#5966F3"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4904, 0.2098, 273.98],
+            "alpha": 1.0,
+            "hex": "#4348D4"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4202, 0.2102, 274.09],
+            "alpha": 1.0,
+            "hex": "#342FBC"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3401, 0.2008, 274.94],
+            "alpha": 1.0,
+            "hex": "#270F9C"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2599, 0.161, 274.76],
+            "alpha": 1.0,
+            "hex": "#18026F"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2224, 0.1386, 276.12],
+            "alpha": 1.0,
+            "hex": "#130059"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2034, 0.1282, 274.67],
+            "alpha": 1.0,
+            "hex": "#0E004F"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4915, 0.2867, 264.03],
+            "alpha": 0.0353,
+            "hex": "#0039FF09"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4915, 0.2867, 264.03],
+            "alpha": 0.0706,
+            "hex": "#0039FF12"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4712, 0.2763, 264.05],
+            "alpha": 0.1529,
+            "hex": "#0034F227"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4856, 0.2906, 264.12],
+            "alpha": 0.2902,
+            "hex": "#0034FF4A"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4739, 0.29, 264.17],
+            "alpha": 0.4353,
+            "hex": "#002EFA6F"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4713, 0.3002, 264.21],
+            "alpha": 0.5608,
+            "hex": "#0025FF8F"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4352, 0.2904, 264.17],
+            "alpha": 0.651,
+            "hex": "#0014EDA6"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3749, 0.2555, 264.12],
+            "alpha": 0.7373,
+            "hex": "#0007C5BC"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3392, 0.2329, 265.02],
+            "alpha": 0.8157,
+            "hex": "#0600ADD0"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3136, 0.2045, 270.65],
+            "alpha": 0.9412,
+            "hex": "#1A0096F0"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2542, 0.1614, 273.78],
+            "alpha": 0.99,
+            "hex": "#16006EFC"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.218, 0.1373, 274.75],
+            "alpha": 0.99,
+            "hex": "#110057FC"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1988, 0.1269, 273.19],
+            "alpha": 0.99,
+            "hex": "#0C004DFC"
+          }
+        }
+      },
+      "spotify": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9881, 0.0191, 148.09],
+            "alpha": 1.0,
+            "hex": "#F3FFF4"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9696, 0.0497, 148.86],
+            "alpha": 1.0,
+            "hex": "#DFFFE3"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9291, 0.1196, 147.83],
+            "alpha": 1.0,
+            "hex": "#B0FEBA"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8512, 0.1903, 148.05],
+            "alpha": 1.0,
+            "hex": "#66EF83"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7702, 0.2104, 148.94],
+            "alpha": 1.0,
+            "hex": "#20D762"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6905, 0.1903, 148.98],
+            "alpha": 1.0,
+            "hex": "#15BA53"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6112, 0.1707, 148.92],
+            "alpha": 1.0,
+            "hex": "#099E44"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5097, 0.1396, 150.15],
+            "alpha": 1.0,
+            "hex": "#017B37"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4305, 0.119, 149.88],
+            "alpha": 1.0,
+            "hex": "#006129"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3394, 0.0892, 150.21],
+            "alpha": 1.0,
+            "hex": "#05441D"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.26, 0.0698, 151.11],
+            "alpha": 1.0,
+            "hex": "#002D11"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2204, 0.0594, 150.91],
+            "alpha": 1.0,
+            "hex": "#00220B"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2013, 0.0579, 148.29],
+            "alpha": 1.0,
+            "hex": "#001D06"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8667, 0.2922, 142.79],
+            "alpha": 0.0471,
+            "hex": "#00FF160C"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.867, 0.2899, 143.04],
+            "alpha": 0.1255,
+            "hex": "#00FF2020"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8587, 0.2869, 143.06],
+            "alpha": 0.3098,
+            "hex": "#00FC214F"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7984, 0.2595, 143.94],
+            "alpha": 0.6,
+            "hex": "#00E43099"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7503, 0.2244, 146.78],
+            "alpha": 0.8745,
+            "hex": "#00D14CDF"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6704, 0.1975, 147.35],
+            "alpha": 0.9176,
+            "hex": "#00B444EA"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5998, 0.1731, 148.13],
+            "alpha": 0.9647,
+            "hex": "#009A3DF6"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5054, 0.1399, 149.81],
+            "alpha": 0.99,
+            "hex": "#007A35FC"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4253, 0.1189, 149.4],
+            "alpha": 0.99,
+            "hex": "#005F27FC"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3254, 0.0902, 149.73],
+            "alpha": 0.9804,
+            "hex": "#004019FA"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2523, 0.0692, 150.16],
+            "alpha": 0.99,
+            "hex": "#002B0FFC"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2119, 0.0588, 149.71],
+            "alpha": 0.99,
+            "hex": "#002009FC"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1923, 0.0584, 146.25],
+            "alpha": 0.99,
+            "hex": "#001B03FC"
+          }
+        }
+      }
+    }
+  },
+  "dark": {
+    "palette": {
+      "neutral": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2002, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#161616"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2308, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#1D1D1D"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2478, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#212121"
+          }
+        },
+        "150": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2686, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#262626"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3171, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#323232"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4349, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#515151"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5032, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#646464"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6133, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#848484"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.709, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#A1A1A1"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7889, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#BABABA"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8545, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#CFCFCF"
+          }
+        },
+        "850": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8914, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#DBDBDB"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9249, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#E6E6E6"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9494, 0.0014, 285.06],
+            "alpha": 1.0,
+            "hex": "#EEEEEF"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9642, 0.0, 0.0],
+            "alpha": 1.0,
+            "hex": "#F3F3F3"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2441, 0.0503, 82.06],
+            "alpha": 0.12,
+            "hex": "#2C1D001F"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.884, 0.1202, 83.36],
+            "alpha": 0.0424,
+            "hex": "#FFD2770B"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9164, 0.0876, 84.22],
+            "alpha": 0.0593,
+            "hex": "#FFDFA00F"
+          }
+        },
+        "A150": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9388, 0.064, 84.48],
+            "alpha": 0.0805,
+            "hex": "#FFE8BB15"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.964, 0.0374, 84.59],
+            "alpha": 0.1314,
+            "hex": "#FFF2D722"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9846, 0.0159, 84.6],
+            "alpha": 0.2627,
+            "hex": "#FFF9EE43"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9894, 0.0108, 84.59],
+            "alpha": 0.3432,
+            "hex": "#FFFBF458"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.994, 0.0061, 84.59],
+            "alpha": 0.4788,
+            "hex": "#FFFDF97A"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9963, 0.0037, 84.6],
+            "alpha": 0.6017,
+            "hex": "#FFFEFB99"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9977, 0.0023, 84.61],
+            "alpha": 0.7076,
+            "hex": "#FFFEFDB4"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9986, 0.0014, 84.64],
+            "alpha": 0.7966,
+            "hex": "#FFFEFECB"
+          }
+        },
+        "A850": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.999, 0.0009, 84.68],
+            "alpha": 0.8475,
+            "hex": "#FFFFFED8"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9993, 0.0006, 84.74],
+            "alpha": 0.8941,
+            "hex": "#FFFFFEE4"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.998, 0.0011, 292.86],
+            "alpha": 0.9304,
+            "hex": "#FEFEFFED"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9997, 0.0002, 85.06],
+            "alpha": 0.9492,
+            "hex": "#FFFFFFF2"
+          }
+        }
+      },
+      "slate": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1954, 0.0087, 264.35],
+            "alpha": 1.0,
+            "hex": "#131519"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2246, 0.0074, 248.2],
+            "alpha": 1.0,
+            "hex": "#191C1F"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2468, 0.0105, 260.7],
+            "alpha": 1.0,
+            "hex": "#1E2126"
+          }
+        },
+        "150": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2672, 0.0087, 255.6],
+            "alpha": 1.0,
+            "hex": "#23262A"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3152, 0.0106, 254.02],
+            "alpha": 1.0,
+            "hex": "#2E3237"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4361, 0.0188, 257.27],
+            "alpha": 1.0,
+            "hex": "#4B525C"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5034, 0.0188, 254.03],
+            "alpha": 1.0,
+            "hex": "#5D656F"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6129, 0.0198, 253.45],
+            "alpha": 1.0,
+            "hex": "#7C8590"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7085, 0.0191, 253.42],
+            "alpha": 1.0,
+            "hex": "#99A2AD"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7889, 0.0168, 253.97],
+            "alpha": 1.0,
+            "hex": "#B3BBC5"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8553, 0.013, 255.56],
+            "alpha": 1.0,
+            "hex": "#CAD0D8"
+          }
+        },
+        "850": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8901, 0.0094, 258.38],
+            "alpha": 1.0,
+            "hex": "#D7DBE1"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9246, 0.0059, 264.52],
+            "alpha": 1.0,
+            "hex": "#E4E6EA"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9512, 0.0035, 248.22],
+            "alpha": 1.0,
+            "hex": "#EDEFF1"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.964, 0.003, 264.51],
+            "alpha": 1.0,
+            "hex": "#F2F3F5"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1954, 0.0087, 264.35],
+            "alpha": 0.01,
+            "hex": "#13151903"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9669, 0.0535, 150.21],
+            "alpha": 0.0299,
+            "hex": "#DCFFE208"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.927, 0.0364, 250.82],
+            "alpha": 0.0565,
+            "hex": "#D6E9FF0E"
+          }
+        },
+        "A150": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9778, 0.0173, 215.08],
+            "alpha": 0.0739,
+            "hex": "#EBFBFF13"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9558, 0.0243, 237.16],
+            "alpha": 0.1304,
+            "hex": "#E2F3FF21"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9196, 0.0395, 254.71],
+            "alpha": 0.2913,
+            "hex": "#D3E6FF4A"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9326, 0.0335, 251.01],
+            "alpha": 0.3739,
+            "hex": "#D9EBFF5F"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9412, 0.0291, 251.4],
+            "alpha": 0.5174,
+            "hex": "#DEEDFF84"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9503, 0.0244, 251.97],
+            "alpha": 0.6435,
+            "hex": "#E3F0FFA4"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9601, 0.0195, 252.92],
+            "alpha": 0.7478,
+            "hex": "#E9F3FFBF"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9711, 0.014, 254.81],
+            "alpha": 0.8304,
+            "hex": "#EFF6FFD4"
+          }
+        },
+        "A850": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9798, 0.0097, 257.83],
+            "alpha": 0.8696,
+            "hex": "#F4F9FFDE"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9877, 0.0058, 264.52],
+            "alpha": 0.9087,
+            "hex": "#F9FBFFE8"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9934, 0.0034, 246.44],
+            "alpha": 0.9391,
+            "hex": "#FBFDFFEF"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9941, 0.0028, 264.51],
+            "alpha": 0.9565,
+            "hex": "#FCFDFFF4"
+          }
+        }
+      },
+      "amber": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2181, 0.0535, 41.2],
+            "alpha": 1.0,
+            "hex": "#2E1005"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2487, 0.0615, 39.83],
+            "alpha": 1.0,
+            "hex": "#391508"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3212, 0.0781, 41.82],
+            "alpha": 1.0,
+            "hex": "#53230F"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4114, 0.0998, 42.33],
+            "alpha": 1.0,
+            "hex": "#763519"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4767, 0.1084, 45.95],
+            "alpha": 1.0,
+            "hex": "#8D4621"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5423, 0.1149, 50.84],
+            "alpha": 1.0,
+            "hex": "#A35929"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6511, 0.1231, 60.89],
+            "alpha": 1.0,
+            "hex": "#C57C37"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7752, 0.1366, 70.0],
+            "alpha": 1.0,
+            "hex": "#EDA548"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8275, 0.1369, 85.12],
+            "alpha": 1.0,
+            "hex": "#EFBF51"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9006, 0.1236, 99.42],
+            "alpha": 1.0,
+            "hex": "#F2E07B"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9372, 0.075, 99.47],
+            "alpha": 1.0,
+            "hex": "#F6ECB2"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9494, 0.0497, 101.13],
+            "alpha": 1.0,
+            "hex": "#F5F0CA"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9572, 0.0161, 95.29],
+            "alpha": 1.0,
+            "hex": "#F4F1E5"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2282, 0.067, 43.45],
+            "alpha": 0.8,
+            "hex": "#350F00CC"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2819, 0.0874, 40.57],
+            "alpha": 0.68,
+            "hex": "#4B1500AD"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5171, 0.1676, 38.45],
+            "alpha": 0.4,
+            "hex": "#B3380066"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6906, 0.2057, 40.4],
+            "alpha": 0.4195,
+            "hex": "#FF61196B"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7155, 0.1884, 44.64],
+            "alpha": 0.5169,
+            "hex": "#FF742984"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7406, 0.1736, 49.84],
+            "alpha": 0.6102,
+            "hex": "#FF84339C"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7824, 0.1555, 60.31],
+            "alpha": 0.7542,
+            "hex": "#FF9E41C0"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8174, 0.1458, 69.86],
+            "alpha": 0.9237,
+            "hex": "#FFB14CEC"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8677, 0.1449, 85.02],
+            "alpha": 0.9322,
+            "hex": "#FFCB55EE"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9364, 0.1296, 99.38],
+            "alpha": 0.9449,
+            "hex": "#FFEC81F1"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9627, 0.0777, 99.43],
+            "alpha": 0.9619,
+            "hex": "#FFF5B8F5"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9783, 0.0518, 101.06],
+            "alpha": 0.9576,
+            "hex": "#FFFAD2F4"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9894, 0.017, 95.12],
+            "alpha": 0.9534,
+            "hex": "#FFFCEFF3"
+          }
+        }
+      },
+      "azure": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2153, 0.0366, 235.39],
+            "alpha": 1.0,
+            "hex": "#061C28"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2513, 0.0418, 234.61],
+            "alpha": 1.0,
+            "hex": "#0A2533"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3244, 0.0565, 236.55],
+            "alpha": 1.0,
+            "hex": "#12384D"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3898, 0.0686, 237.08],
+            "alpha": 1.0,
+            "hex": "#1A4A65"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4564, 0.0885, 242.55],
+            "alpha": 1.0,
+            "hex": "#225C84"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5112, 0.1002, 243.03],
+            "alpha": 1.0,
+            "hex": "#296C9B"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6464, 0.1244, 244.26],
+            "alpha": 1.0,
+            "hex": "#4195D4"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7159, 0.1107, 243.05],
+            "alpha": 1.0,
+            "hex": "#61ABE3"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.785, 0.0853, 239.15],
+            "alpha": 1.0,
+            "hex": "#85C1EA"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8441, 0.0696, 230.27],
+            "alpha": 1.0,
+            "hex": "#9DD5F1"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9143, 0.0338, 225.55],
+            "alpha": 1.0,
+            "hex": "#CCE8F4"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9367, 0.0239, 223.81],
+            "alpha": 1.0,
+            "hex": "#DAEEF6"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9613, 0.0105, 219.91],
+            "alpha": 1.0,
+            "hex": "#EBF4F7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2266, 0.0477, 234.46],
+            "alpha": 0.6842,
+            "hex": "#001F2FAE"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3176, 0.0682, 235.83],
+            "alpha": 0.4737,
+            "hex": "#00375079"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7212, 0.1623, 239.79],
+            "alpha": 0.2261,
+            "hex": "#0EB0FF3A"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7367, 0.1544, 238.42],
+            "alpha": 0.3304,
+            "hex": "#28B5FF54"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7211, 0.1575, 243.39],
+            "alpha": 0.4652,
+            "hex": "#33AEFF77"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7255, 0.1546, 243.54],
+            "alpha": 0.5652,
+            "hex": "#3AAFFF90"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7381, 0.1459, 244.34],
+            "alpha": 0.813,
+            "hex": "#4CB2FFCF"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7793, 0.1224, 242.99],
+            "alpha": 0.8783,
+            "hex": "#6CC0FFE0"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8367, 0.0917, 239.02],
+            "alpha": 0.9087,
+            "hex": "#90D2FFE8"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8806, 0.073, 230.12],
+            "alpha": 0.9391,
+            "hex": "#A6E1FFEF"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9455, 0.035, 225.25],
+            "alpha": 0.9522,
+            "hex": "#D5F3FFF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9629, 0.0245, 223.45],
+            "alpha": 0.9609,
+            "hex": "#E2F7FFF5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9851, 0.0106, 219.12],
+            "alpha": 0.9652,
+            "hex": "#F3FCFFF6"
+          }
+        }
+      },
+      "blue": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2102, 0.0575, 256.42],
+            "alpha": 1.0,
+            "hex": "#051832"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2466, 0.0608, 255.0],
+            "alpha": 1.0,
+            "hex": "#0A213D"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3154, 0.0847, 260.81],
+            "alpha": 1.0,
+            "hex": "#17305C"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3873, 0.1024, 258.75],
+            "alpha": 1.0,
+            "hex": "#1F437A"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.461, 0.1249, 255.4],
+            "alpha": 1.0,
+            "hex": "#20589C"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5133, 0.1434, 256.15],
+            "alpha": 1.0,
+            "hex": "#2666B7"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5943, 0.1618, 255.5],
+            "alpha": 1.0,
+            "hex": "#317EDC"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6948, 0.1251, 255.49],
+            "alpha": 1.0,
+            "hex": "#669FE9"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.779, 0.086, 252.11],
+            "alpha": 1.0,
+            "hex": "#8FBBED"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8465, 0.0565, 250.98],
+            "alpha": 1.0,
+            "hex": "#B2D0F1"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9097, 0.0284, 251.51],
+            "alpha": 1.0,
+            "hex": "#D4E3F4"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9323, 0.0202, 250.44],
+            "alpha": 1.0,
+            "hex": "#DFEAF6"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9492, 0.0132, 251.64],
+            "alpha": 1.0,
+            "hex": "#E8EFF7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2181, 0.0734, 255.59],
+            "alpha": 0.7368,
+            "hex": "#00193BBC"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3108, 0.1074, 256.3],
+            "alpha": 0.4737,
+            "hex": "#002E6579"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5899, 0.224, 260.96],
+            "alpha": 0.2913,
+            "hex": "#2172FF4A"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6261, 0.2023, 259.03],
+            "alpha": 0.4217,
+            "hex": "#2F82FF6C"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6426, 0.1939, 255.97],
+            "alpha": 0.5696,
+            "hex": "#2A8BFF91"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6443, 0.1926, 256.46],
+            "alpha": 0.687,
+            "hex": "#2F8BFFAF"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6588, 0.1842, 255.62],
+            "alpha": 0.8478,
+            "hex": "#3691FFD8"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7414, 0.1354, 255.47],
+            "alpha": 0.9043,
+            "hex": "#6FAEFFE7"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8222, 0.0915, 252.05],
+            "alpha": 0.9217,
+            "hex": "#9AC9FFEB"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8832, 0.0591, 250.9],
+            "alpha": 0.9391,
+            "hex": "#BCDCFFEF"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9408, 0.0293, 251.38],
+            "alpha": 0.9522,
+            "hex": "#DEEDFFF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9583, 0.0206, 250.28],
+            "alpha": 0.9609,
+            "hex": "#E7F3FFF5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9727, 0.0134, 251.44],
+            "alpha": 0.9652,
+            "hex": "#F0F7FFF6"
+          }
+        }
+      },
+      "coral": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2135, 0.0554, 29.41],
+            "alpha": 1.0,
+            "hex": "#2E0D09"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2375, 0.0724, 30.93],
+            "alpha": 1.0,
+            "hex": "#3A0D07"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3035, 0.0904, 32.69],
+            "alpha": 1.0,
+            "hex": "#53180D"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.39, 0.1143, 33.29],
+            "alpha": 1.0,
+            "hex": "#762717"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4567, 0.1296, 35.1],
+            "alpha": 1.0,
+            "hex": "#91351E"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5321, 0.1454, 36.41],
+            "alpha": 1.0,
+            "hex": "#B04628"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6669, 0.1682, 40.03],
+            "alpha": 1.0,
+            "hex": "#E7693A"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7157, 0.1355, 38.93],
+            "alpha": 1.0,
+            "hex": "#EA8361"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7536, 0.1139, 38.39],
+            "alpha": 1.0,
+            "hex": "#ED9579"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8311, 0.0683, 37.83],
+            "alpha": 1.0,
+            "hex": "#F0B9A8"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9155, 0.0278, 34.18],
+            "alpha": 1.0,
+            "hex": "#F5DDD7"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9457, 0.0136, 34.04],
+            "alpha": 1.0,
+            "hex": "#F6EAE7"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9642, 0.0067, 53.09],
+            "alpha": 1.0,
+            "hex": "#F7F2EF"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2373, 0.0834, 34.91],
+            "alpha": 0.64,
+            "hex": "#3D0900A3"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.265, 0.0956, 33.84],
+            "alpha": 0.72,
+            "hex": "#490A00B8"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4408, 0.1633, 32.83],
+            "alpha": 0.48,
+            "hex": "#981B007A"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6564, 0.2316, 33.24],
+            "alpha": 0.4195,
+            "hex": "#FF40146B"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6728, 0.2175, 35.01],
+            "alpha": 0.5339,
+            "hex": "#FF512388"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6888, 0.2041, 36.41],
+            "alpha": 0.6653,
+            "hex": "#FF5F30AA"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7154, 0.184, 40.01],
+            "alpha": 0.8983,
+            "hex": "#FF733EE5"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.761, 0.1469, 39.05],
+            "alpha": 0.911,
+            "hex": "#FF8E68E8"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7943, 0.122, 38.54],
+            "alpha": 0.9237,
+            "hex": "#FFA081EC"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8688, 0.0724, 38.05],
+            "alpha": 0.9364,
+            "hex": "#FFC4B2EF"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9431, 0.029, 34.57],
+            "alpha": 0.9576,
+            "hex": "#FFE6DFF4"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9714, 0.0142, 34.75],
+            "alpha": 0.9619,
+            "hex": "#FFF2EFF5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9875, 0.007, 53.94],
+            "alpha": 0.9661,
+            "hex": "#FFFAF7F6"
+          }
+        }
+      },
+      "green": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2128, 0.052, 146.01],
+            "alpha": 1.0,
+            "hex": "#061F09"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.257, 0.0639, 145.07],
+            "alpha": 1.0,
+            "hex": "#0B2B0E"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3198, 0.0798, 145.46],
+            "alpha": 1.0,
+            "hex": "#123D17"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3936, 0.0929, 147.76],
+            "alpha": 1.0,
+            "hex": "#1B5327"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4429, 0.1149, 144.57],
+            "alpha": 1.0,
+            "hex": "#216326"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4993, 0.1248, 145.74],
+            "alpha": 1.0,
+            "hex": "#297533"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6264, 0.1578, 145.46],
+            "alpha": 1.0,
+            "hex": "#3BA047"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6899, 0.1568, 148.36],
+            "alpha": 1.0,
+            "hex": "#48B561"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7688, 0.1543, 150.8],
+            "alpha": 1.0,
+            "hex": "#5ECF7F"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8348, 0.144, 150.05],
+            "alpha": 1.0,
+            "hex": "#7EE396"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9093, 0.0813, 150.15],
+            "alpha": 1.0,
+            "hex": "#BBF1C5"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9457, 0.044, 150.46],
+            "alpha": 1.0,
+            "hex": "#D9F6DE"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9624, 0.0216, 149.92],
+            "alpha": 1.0,
+            "hex": "#E9F7EB"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2245, 0.0738, 143.56],
+            "alpha": 0.6842,
+            "hex": "#002402AE"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.345, 0.1171, 142.4],
+            "alpha": 0.44,
+            "hex": "#01470070"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8671, 0.2927, 142.54],
+            "alpha": 0.1709,
+            "hex": "#0DFF0E2C"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.873, 0.2656, 144.41],
+            "alpha": 0.265,
+            "hex": "#31FF4E44"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8738, 0.2707, 142.99],
+            "alpha": 0.3333,
+            "hex": "#3DFF4055"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8779, 0.2537, 144.17],
+            "alpha": 0.4103,
+            "hex": "#48FF5869"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8824, 0.2397, 144.66],
+            "alpha": 0.594,
+            "hex": "#56FF6697"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8886, 0.2137, 147.6],
+            "alpha": 0.6838,
+            "hex": "#60FF82AE"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8975, 0.1863, 150.3],
+            "alpha": 0.7949,
+            "hex": "#71FF99CB"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9104, 0.1601, 149.78],
+            "alpha": 0.8803,
+            "hex": "#8DFFA7E0"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9487, 0.0857, 149.94],
+            "alpha": 0.9402,
+            "hex": "#C6FFD0F0"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9716, 0.0456, 150.2],
+            "alpha": 0.9615,
+            "hex": "#E1FFE6F5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9859, 0.0223, 149.46],
+            "alpha": 0.9658,
+            "hex": "#F1FFF3F6"
+          }
+        }
+      },
+      "indigo": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1985, 0.0552, 277.05],
+            "alpha": 1.0,
+            "hex": "#10122E"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2478, 0.0887, 277.75],
+            "alpha": 1.0,
+            "hex": "#19194A"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3162, 0.1125, 277.82],
+            "alpha": 1.0,
+            "hex": "#272769"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3763, 0.1422, 278.1],
+            "alpha": 1.0,
+            "hex": "#34328A"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.462, 0.1564, 281.03],
+            "alpha": 1.0,
+            "hex": "#4D47AC"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.522, 0.1796, 281.57],
+            "alpha": 1.0,
+            "hex": "#5D54CC"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6065, 0.1699, 280.46],
+            "alpha": 1.0,
+            "hex": "#7271E4"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7001, 0.1226, 280.13],
+            "alpha": 1.0,
+            "hex": "#9095E9"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7483, 0.1007, 281.14],
+            "alpha": 1.0,
+            "hex": "#A2A6EC"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8345, 0.0603, 280.81],
+            "alpha": 1.0,
+            "hex": "#C1C5F0"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.903, 0.0315, 281.75],
+            "alpha": 1.0,
+            "hex": "#DBDDF4"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9306, 0.0191, 279.46],
+            "alpha": 1.0,
+            "hex": "#E5E7F5"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9517, 0.0121, 286.02],
+            "alpha": 1.0,
+            "hex": "#EEEEF7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3174, 0.2182, 264.09],
+            "alpha": 0.1579,
+            "hex": "#00029E28"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4847, 0.2913, 269.44],
+            "alpha": 0.213,
+            "hex": "#2F28FF36"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5373, 0.2586, 274.26],
+            "alpha": 0.3478,
+            "hex": "#4D49FF59"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5535, 0.2492, 276.06],
+            "alpha": 0.4913,
+            "hex": "#5650FF7D"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.599, 0.2232, 280.29],
+            "alpha": 0.6391,
+            "hex": "#6E63FFA3"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6065, 0.2192, 281.21],
+            "alpha": 0.7783,
+            "hex": "#7266FFC6"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6554, 0.1877, 280.37],
+            "alpha": 0.8826,
+            "hex": "#7F7DFFE1"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.747, 0.1327, 280.16],
+            "alpha": 0.9043,
+            "hex": "#9DA3FFE7"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7919, 0.1077, 281.2],
+            "alpha": 0.9174,
+            "hex": "#AFB3FFEA"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8733, 0.0634, 280.92],
+            "alpha": 0.9348,
+            "hex": "#CDD1FFEE"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9338, 0.0325, 281.91],
+            "alpha": 0.9522,
+            "hex": "#E5E7FFF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9595, 0.0195, 279.66],
+            "alpha": 0.9565,
+            "hex": "#EFF1FFF4"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9753, 0.0123, 286.38],
+            "alpha": 0.9652,
+            "hex": "#F6F6FFF6"
+          }
+        }
+      },
+      "magenta": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2033, 0.0565, 346.25],
+            "alpha": 1.0,
+            "hex": "#280A1C"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2342, 0.0729, 344.26],
+            "alpha": 1.0,
+            "hex": "#340C26"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2969, 0.0765, 342.93],
+            "alpha": 1.0,
+            "hex": "#461B37"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3968, 0.1016, 344.09],
+            "alpha": 1.0,
+            "hex": "#6B2D54"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4602, 0.1282, 344.33],
+            "alpha": 1.0,
+            "hex": "#873569"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5271, 0.1454, 344.2],
+            "alpha": 1.0,
+            "hex": "#A2427F"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6439, 0.1608, 346.44],
+            "alpha": 1.0,
+            "hex": "#D05FA1"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7239, 0.1586, 341.64],
+            "alpha": 1.0,
+            "hex": "#E77AC2"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.793, 0.1333, 333.8],
+            "alpha": 1.0,
+            "hex": "#EF9ADF"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8702, 0.0811, 327.54],
+            "alpha": 1.0,
+            "hex": "#F2C2F0"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.907, 0.0503, 329.0],
+            "alpha": 1.0,
+            "hex": "#F4D5F1"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9442, 0.0256, 325.62],
+            "alpha": 1.0,
+            "hex": "#F6E7F6"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9587, 0.0153, 325.42],
+            "alpha": 1.0,
+            "hex": "#F7EEF7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2301, 0.0944, 355.46],
+            "alpha": 0.5238,
+            "hex": "#3B001F86"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.32, 0.1318, 353.97],
+            "alpha": 0.4286,
+            "hex": "#6000376D"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6726, 0.2522, 352.77],
+            "alpha": 0.2161,
+            "hex": "#FF31A437"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7082, 0.2246, 348.78],
+            "alpha": 0.3729,
+            "hex": "#FF55B75F"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7107, 0.2261, 347.29],
+            "alpha": 0.4915,
+            "hex": "#FF56BC7D"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7222, 0.2174, 346.06],
+            "alpha": 0.6059,
+            "hex": "#FF5FC19B"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7438, 0.1927, 347.19],
+            "alpha": 0.8008,
+            "hex": "#FF71C3CC"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.777, 0.1731, 341.97],
+            "alpha": 0.8983,
+            "hex": "#FF85D5E5"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8311, 0.1412, 334.01],
+            "alpha": 0.9322,
+            "hex": "#FFA4EDEE"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9044, 0.0849, 327.77],
+            "alpha": 0.9449,
+            "hex": "#FFCCFDF1"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9372, 0.0522, 329.3],
+            "alpha": 0.9534,
+            "hex": "#FFDEFCF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9699, 0.0263, 326.07],
+            "alpha": 0.9619,
+            "hex": "#FFEFFFF5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9819, 0.0157, 326.08],
+            "alpha": 0.9661,
+            "hex": "#FFF6FFF6"
+          }
+        }
+      },
+      "orange": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2144, 0.0558, 37.69],
+            "alpha": 1.0,
+            "hex": "#2E0E05"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2433, 0.0653, 36.72],
+            "alpha": 1.0,
+            "hex": "#391207"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3232, 0.0862, 37.45],
+            "alpha": 1.0,
+            "hex": "#57200F"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4034, 0.1071, 37.85],
+            "alpha": 1.0,
+            "hex": "#772F18"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4635, 0.1161, 40.76],
+            "alpha": 1.0,
+            "hex": "#8D3E1F"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5236, 0.132, 40.15],
+            "alpha": 1.0,
+            "hex": "#A74A27"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6509, 0.152, 44.54],
+            "alpha": 1.0,
+            "hex": "#D96C37"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7134, 0.148, 52.68],
+            "alpha": 1.0,
+            "hex": "#E9853F"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7694, 0.1282, 63.44],
+            "alpha": 1.0,
+            "hex": "#EDA156"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.845, 0.0798, 65.15],
+            "alpha": 1.0,
+            "hex": "#F1C295"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9055, 0.0433, 67.21],
+            "alpha": 1.0,
+            "hex": "#F4DBC2"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9321, 0.0289, 72.44],
+            "alpha": 1.0,
+            "hex": "#F5E6D4"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9485, 0.0161, 64.58],
+            "alpha": 1.0,
+            "hex": "#F6ECE3"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2242, 0.0696, 40.54],
+            "alpha": 0.8,
+            "hex": "#350C00CC"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.27, 0.0879, 38.25],
+            "alpha": 0.72,
+            "hex": "#481100B8"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.527, 0.1832, 35.36],
+            "alpha": 0.4,
+            "hex": "#BD310066"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6737, 0.2178, 36.7],
+            "alpha": 0.4237,
+            "hex": "#FF52176C"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6949, 0.2015, 39.89],
+            "alpha": 0.5169,
+            "hex": "#FF642584"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7022, 0.1951, 39.82],
+            "alpha": 0.6271,
+            "hex": "#FF6A2FA0"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7297, 0.1761, 44.38],
+            "alpha": 0.839,
+            "hex": "#FF7D3DD6"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7609, 0.1606, 52.54],
+            "alpha": 0.9068,
+            "hex": "#FF9143E7"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8112, 0.137, 63.36],
+            "alpha": 0.9237,
+            "hex": "#FFAD5BEC"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8807, 0.0843, 65.2],
+            "alpha": 0.9407,
+            "hex": "#FFCD9DF0"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9356, 0.0453, 67.3],
+            "alpha": 0.9534,
+            "hex": "#FFE5CAF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9603, 0.0302, 72.54],
+            "alpha": 0.9576,
+            "hex": "#FFEFDCF4"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9743, 0.0169, 64.84],
+            "alpha": 0.9619,
+            "hex": "#FFF5EBF5"
+          }
+        }
+      },
+      "purple": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.1976, 0.0488, 312.78],
+            "alpha": 1.0,
+            "hex": "#1D0E25"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2368, 0.0588, 312.91],
+            "alpha": 1.0,
+            "hex": "#281532"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3139, 0.08, 314.49],
+            "alpha": 1.0,
+            "hex": "#40234D"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4179, 0.109, 315.85],
+            "alpha": 1.0,
+            "hex": "#633774"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.471, 0.1261, 313.71],
+            "alpha": 1.0,
+            "hex": "#74428C"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5123, 0.1293, 313.81],
+            "alpha": 1.0,
+            "hex": "#814D9A"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6174, 0.135, 312.57],
+            "alpha": 1.0,
+            "hex": "#A16BBF"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7216, 0.1292, 315.47],
+            "alpha": 1.0,
+            "hex": "#C48BDC"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7954, 0.1128, 315.25],
+            "alpha": 1.0,
+            "hex": "#D8A6EE"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8533, 0.0766, 316.21],
+            "alpha": 1.0,
+            "hex": "#E3C0F1"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8919, 0.0504, 314.49],
+            "alpha": 1.0,
+            "hex": "#E8D2F3"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9317, 0.0251, 311.56],
+            "alpha": 1.0,
+            "hex": "#EEE4F5"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9583, 0.0119, 312.91],
+            "alpha": 1.0,
+            "hex": "#F4EFF7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2299, 0.1113, 318.4],
+            "alpha": 0.3333,
+            "hex": "#31003D55"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6429, 0.304, 318.29],
+            "alpha": 0.1087,
+            "hex": "#D415FF1C"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6896, 0.2582, 318.16],
+            "alpha": 0.2261,
+            "hex": "#DA53FF3A"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7201, 0.2283, 317.87],
+            "alpha": 0.3957,
+            "hex": "#DD6BFF65"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7156, 0.2191, 314.96],
+            "alpha": 0.5,
+            "hex": "#D56FFF80"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7312, 0.2053, 314.88],
+            "alpha": 0.5609,
+            "hex": "#D779FF8F"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7601, 0.1753, 313.18],
+            "alpha": 0.7217,
+            "hex": "#D88CFFB8"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8042, 0.1475, 315.84],
+            "alpha": 0.8478,
+            "hex": "#E4A0FFD8"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8373, 0.1199, 315.44],
+            "alpha": 0.9261,
+            "hex": "#E8B2FFEC"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8904, 0.0805, 316.44],
+            "alpha": 0.9391,
+            "hex": "#F0CBFFEF"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9251, 0.0525, 314.77],
+            "alpha": 0.9478,
+            "hex": "#F4DCFFF2"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9607, 0.0259, 312.0],
+            "alpha": 0.9565,
+            "hex": "#F8EDFFF4"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9821, 0.0121, 313.65],
+            "alpha": 0.9652,
+            "hex": "#FCF7FFF6"
+          }
+        }
+      },
+      "red": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2012, 0.0564, 20.32],
+            "alpha": 1.0,
+            "hex": "#2B090B"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2342, 0.0751, 24.06],
+            "alpha": 1.0,
+            "hex": "#3A0A0B"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2892, 0.0935, 25.2],
+            "alpha": 1.0,
+            "hex": "#501111"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3685, 0.1212, 25.96],
+            "alpha": 1.0,
+            "hex": "#721B1A"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4463, 0.1479, 27.92],
+            "alpha": 1.0,
+            "hex": "#952620"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5264, 0.1737, 29.29],
+            "alpha": 1.0,
+            "hex": "#BA3327"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6394, 0.189, 30.23],
+            "alpha": 1.0,
+            "hex": "#E8523F"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6752, 0.1634, 29.58],
+            "alpha": 1.0,
+            "hex": "#EA6958"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7403, 0.118, 28.52],
+            "alpha": 1.0,
+            "hex": "#EC8D80"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8186, 0.074, 28.08],
+            "alpha": 1.0,
+            "hex": "#F0B2A9"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9045, 0.0315, 24.93],
+            "alpha": 1.0,
+            "hex": "#F4D8D5"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9349, 0.0188, 25.4],
+            "alpha": 1.0,
+            "hex": "#F6E5E3"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9581, 0.0087, 25.56],
+            "alpha": 1.0,
+            "hex": "#F7EFEE"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2262, 0.0926, 28.64],
+            "alpha": 0.5714,
+            "hex": "#3D000192"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2917, 0.1182, 29.64],
+            "alpha": 0.56,
+            "hex": "#5901008F"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5437, 0.2204, 29.63],
+            "alpha": 0.32,
+            "hex": "#D2090052"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6388, 0.247, 29.0],
+            "alpha": 0.4025,
+            "hex": "#FF241C67"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6484, 0.2378, 29.38],
+            "alpha": 0.5508,
+            "hex": "#FF34268C"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6574, 0.2294, 29.93],
+            "alpha": 0.7076,
+            "hex": "#FF3F2DB4"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6837, 0.2057, 30.41],
+            "alpha": 0.9025,
+            "hex": "#FF5943E6"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7176, 0.1768, 29.79],
+            "alpha": 0.911,
+            "hex": "#FF715EE8"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7825, 0.1269, 28.74],
+            "alpha": 0.9195,
+            "hex": "#FF9889EA"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8555, 0.0784, 28.34],
+            "alpha": 0.9364,
+            "hex": "#FFBDB3EF"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9346, 0.0329, 25.35],
+            "alpha": 0.9534,
+            "hex": "#FFE2DEF3"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9603, 0.0195, 25.98],
+            "alpha": 0.9619,
+            "hex": "#FFEDEBF5"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9812, 0.0091, 26.65],
+            "alpha": 0.9661,
+            "hex": "#FFF7F6F6"
+          }
+        }
+      },
+      "teal": {
+        "25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.207, 0.0281, 211.72],
+            "alpha": 1.0,
+            "hex": "#061B1F"
+          }
+        },
+        "50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2423, 0.0336, 211.82],
+            "alpha": 1.0,
+            "hex": "#092429"
+          }
+        },
+        "100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3056, 0.0426, 209.95],
+            "alpha": 1.0,
+            "hex": "#10353B"
+          }
+        },
+        "200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.3936, 0.0549, 209.51],
+            "alpha": 1.0,
+            "hex": "#1B4E56"
+          }
+        },
+        "300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.4599, 0.0637, 207.04],
+            "alpha": 1.0,
+            "hex": "#24626A"
+          }
+        },
+        "400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.5083, 0.0708, 206.87],
+            "alpha": 1.0,
+            "hex": "#2A717A"
+          }
+        },
+        "500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.6294, 0.0876, 206.11],
+            "alpha": 1.0,
+            "hex": "#3B98A3"
+          }
+        },
+        "600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7033, 0.0805, 205.99],
+            "alpha": 1.0,
+            "hex": "#5DAEB8"
+          }
+        },
+        "700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.7685, 0.0696, 205.3],
+            "alpha": 1.0,
+            "hex": "#7DC1C9"
+          }
+        },
+        "800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8601, 0.0539, 203.63],
+            "alpha": 1.0,
+            "hex": "#A8DCE1"
+          }
+        },
+        "900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9162, 0.0369, 205.09],
+            "alpha": 1.0,
+            "hex": "#C8EBEF"
+          }
+        },
+        "950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9391, 0.0336, 203.62],
+            "alpha": 1.0,
+            "hex": "#D2F2F5"
+          }
+        },
+        "975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9623, 0.0159, 201.97],
+            "alpha": 1.0,
+            "hex": "#E7F6F7"
+          }
+        },
+        "A25": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2139, 0.0367, 207.25],
+            "alpha": 0.6842,
+            "hex": "#001E22AE"
+          }
+        },
+        "A50": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.2881, 0.0495, 207.45],
+            "alpha": 0.5263,
+            "hex": "#00313786"
+          }
+        },
+        "A100": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.826, 0.141, 204.41],
+            "alpha": 0.1579,
+            "hex": "#00E0F028"
+          }
+        },
+        "A200": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8641, 0.1402, 205.85],
+            "alpha": 0.2652,
+            "hex": "#31ECFF44"
+          }
+        },
+        "A300": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8757, 0.1359, 204.02],
+            "alpha": 0.3522,
+            "hex": "#43F0FF5A"
+          }
+        },
+        "A400": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8758, 0.1334, 204.53],
+            "alpha": 0.4217,
+            "hex": "#49EFFF6C"
+          }
+        },
+        "A500": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.879, 0.1284, 204.86],
+            "alpha": 0.6,
+            "hex": "#55EFFF99"
+          }
+        },
+        "A600": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.8986, 0.1069, 204.85],
+            "alpha": 0.6913,
+            "hex": "#7EF2FFB0"
+          }
+        },
+        "A700": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9199, 0.0857, 204.27],
+            "alpha": 0.7652,
+            "hex": "#9DF6FFC3"
+          }
+        },
+        "A800": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9461, 0.0601, 202.9],
+            "alpha": 0.8696,
+            "hex": "#BEFAFFDE"
+          }
+        },
+        "A900": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9628, 0.039, 204.54],
+            "alpha": 0.9304,
+            "hex": "#D5FBFFED"
+          }
+        },
+        "A950": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9683, 0.0347, 203.24],
+            "alpha": 0.9565,
+            "hex": "#DBFCFFF4"
+          }
+        },
+        "A975": {
+          "type": "color",
+          "value": {
+            "colorSpace": "oklch",
+            "components": [0.9862, 0.0163, 201.32],
+            "alpha": 0.9652,
+            "hex": "#EFFEFFF6"
+          }
+        }
+      },
+      "tenant": {
+        "airbnb": {
+          "25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2042, 0.0636, 18.8],
+              "alpha": 1.0,
+              "hex": "#2E070B"
+            }
+          },
+          "50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2235, 0.0723, 19.35],
+              "alpha": 1.0,
+              "hex": "#36080D"
+            }
+          },
+          "100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2623, 0.0879, 18.61],
+              "alpha": 1.0,
+              "hex": "#460B13"
+            }
+          },
+          "200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3382, 0.1122, 18.3],
+              "alpha": 1.0,
+              "hex": "#651520"
+            }
+          },
+          "300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4161, 0.1353, 17.84],
+              "alpha": 1.0,
+              "hex": "#86212F"
+            }
+          },
+          "400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4843, 0.1522, 17.86],
+              "alpha": 1.0,
+              "hex": "#A32E3D"
+            }
+          },
+          "500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.5821, 0.1837, 17.52],
+              "alpha": 1.0,
+              "hex": "#D13D51"
+            }
+          },
+          "600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6494, 0.1837, 17.21],
+              "alpha": 1.0,
+              "hex": "#E95465"
+            }
+          },
+          "700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.728, 0.1275, 17.03],
+              "alpha": 1.0,
+              "hex": "#EC848A"
+            }
+          },
+          "800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8049, 0.079, 16.94],
+              "alpha": 1.0,
+              "hex": "#EEABAD"
+            }
+          },
+          "900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8913, 0.0405, 15.94],
+              "alpha": 1.0,
+              "hex": "#F5D1D2"
+            }
+          },
+          "950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9308, 0.0164, 17.2],
+              "alpha": 1.0,
+              "hex": "#F3E4E4"
+            }
+          },
+          "975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9515, 0.0075, 16.72],
+              "alpha": 1.0,
+              "hex": "#F4EDED"
+            }
+          },
+          "A25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2233, 0.0904, 24.53],
+              "alpha": 0.6667,
+              "hex": "#3C0004AA"
+            }
+          },
+          "A50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2613, 0.1059, 25.09],
+              "alpha": 0.619,
+              "hex": "#4C00069E"
+            }
+          },
+          "A100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3736, 0.1518, 26.03],
+              "alpha": 0.4762,
+              "hex": "#7E000C79"
+            }
+          },
+          "A200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6344, 0.251, 25.43],
+              "alpha": 0.3475,
+              "hex": "#FF152D59"
+            }
+          },
+          "A300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6478, 0.2385, 22.0],
+              "alpha": 0.4873,
+              "hex": "#FF2E467C"
+            }
+          },
+          "A400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6609, 0.2265, 20.31],
+              "alpha": 0.6102,
+              "hex": "#FF3E549C"
+            }
+          },
+          "A500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.67, 0.2188, 18.47],
+              "alpha": 0.8051,
+              "hex": "#FF475FCD"
+            }
+          },
+          "A600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6923, 0.1991, 17.58],
+              "alpha": 0.9068,
+              "hex": "#FF5B6DE7"
+            }
+          },
+          "A700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.7694, 0.1369, 17.31],
+              "alpha": 0.9195,
+              "hex": "#FF8E94EA"
+            }
+          },
+          "A800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8463, 0.0843, 17.26],
+              "alpha": 0.928,
+              "hex": "#FFB7B9ED"
+            }
+          },
+          "A900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9181, 0.042, 16.28],
+              "alpha": 0.9576,
+              "hex": "#FFD9DAF4"
+            }
+          },
+          "A950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9649, 0.0172, 18.15],
+              "alpha": 0.9492,
+              "hex": "#FFEFEFF2"
+            }
+          },
+          "A975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9835, 0.0079, 18.59],
+              "alpha": 0.9534,
+              "hex": "#FFF8F7F3"
+            }
+          }
+        },
+        "discord": {
+          "25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2017, 0.1041, 274.73],
+              "alpha": 1.0,
+              "hex": "#0D0944"
+            }
+          },
+          "50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2215, 0.112, 276.23],
+              "alpha": 1.0,
+              "hex": "#120C4D"
+            }
+          },
+          "100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2611, 0.1278, 275.24],
+              "alpha": 1.0,
+              "hex": "#181460"
+            }
+          },
+          "200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3388, 0.161, 274.87],
+              "alpha": 1.0,
+              "hex": "#262388"
+            }
+          },
+          "300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4173, 0.1675, 274.04],
+              "alpha": 1.0,
+              "hex": "#353BA5"
+            }
+          },
+          "400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4854, 0.1683, 273.93],
+              "alpha": 1.0,
+              "hex": "#4550BC"
+            }
+          },
+          "500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.5727, 0.1674, 274.05],
+              "alpha": 1.0,
+              "hex": "#5C6BD9"
+            }
+          },
+          "600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6486, 0.1447, 273.29],
+              "alpha": 1.0,
+              "hex": "#7386E6"
+            }
+          },
+          "700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.7262, 0.1039, 273.12],
+              "alpha": 1.0,
+              "hex": "#91A2E8"
+            }
+          },
+          "800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.815, 0.0722, 273.35],
+              "alpha": 1.0,
+              "hex": "#B3C0F2"
+            }
+          },
+          "900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8928, 0.0312, 271.67],
+              "alpha": 1.0,
+              "hex": "#D4DBF1"
+            }
+          },
+          "950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9405, 0.0168, 271.2],
+              "alpha": 1.0,
+              "hex": "#E7EBF7"
+            }
+          },
+          "975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9611, 0.0071, 268.49],
+              "alpha": 1.0,
+              "hex": "#F0F2F7"
+            }
+          },
+          "A25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2324, 0.1548, 268.22],
+              "alpha": 0.5714,
+              "hex": "#09006492"
+            }
+          },
+          "A50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3043, 0.2032, 267.98],
+              "alpha": 0.4286,
+              "hex": "#1100926D"
+            }
+          },
+          "A100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4656, 0.3038, 267.57],
+              "alpha": 0.3087,
+              "hex": "#2312FF4F"
+            }
+          },
+          "A200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4997, 0.2819, 271.45],
+              "alpha": 0.4826,
+              "hex": "#3A32FF7B"
+            }
+          },
+          "A300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.5518, 0.2483, 272.69],
+              "alpha": 0.6087,
+              "hex": "#4B53FF9B"
+            }
+          },
+          "A400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.5941, 0.2216, 273.34],
+              "alpha": 0.7087,
+              "hex": "#5A68FFB5"
+            }
+          },
+          "A500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6397, 0.1935, 273.87],
+              "alpha": 0.8348,
+              "hex": "#6A7CFFD5"
+            }
+          },
+          "A600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6976, 0.1585, 273.25],
+              "alpha": 0.8913,
+              "hex": "#7F94FFE3"
+            }
+          },
+          "A700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.7779, 0.1128, 273.14],
+              "alpha": 0.9,
+              "hex": "#9FB2FFE6"
+            }
+          },
+          "A800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8474, 0.0754, 273.39],
+              "alpha": 0.9435,
+              "hex": "#BDCAFFF1"
+            }
+          },
+          "A900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.932, 0.0325, 271.75],
+              "alpha": 0.9391,
+              "hex": "#E0E8FFEF"
+            }
+          },
+          "A950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9638, 0.0171, 271.29],
+              "alpha": 0.9652,
+              "hex": "#EFF3FFF6"
+            }
+          },
+          "A975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9849, 0.0071, 268.61],
+              "alpha": 0.9652,
+              "hex": "#F8FAFFF6"
+            }
+          }
+        },
+        "spotify": {
+          "25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2012, 0.047, 149.75],
+              "alpha": 1.0,
+              "hex": "#041C0A"
+            }
+          },
+          "50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2216, 0.0474, 150.99],
+              "alpha": 1.0,
+              "hex": "#07210F"
+            }
+          },
+          "100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.262, 0.0561, 151.46],
+              "alpha": 1.0,
+              "hex": "#0B2C16"
+            }
+          },
+          "200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3397, 0.072, 150.07],
+              "alpha": 1.0,
+              "hex": "#174223"
+            }
+          },
+          "300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.4265, 0.0958, 149.91],
+              "alpha": 1.0,
+              "hex": "#1F5D31"
+            }
+          },
+          "400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.5047, 0.1129, 149.93],
+              "alpha": 1.0,
+              "hex": "#2A7640"
+            }
+          },
+          "500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6005, 0.1355, 149.09],
+              "alpha": 1.0,
+              "hex": "#399651"
+            }
+          },
+          "600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.6788, 0.1521, 149.0],
+              "alpha": 1.0,
+              "hex": "#46B161"
+            }
+          },
+          "700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.7551, 0.1674, 149.17],
+              "alpha": 1.0,
+              "hex": "#53CC72"
+            }
+          },
+          "800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.833, 0.1513, 148.18],
+              "alpha": 1.0,
+              "hex": "#7DE38F"
+            }
+          },
+          "900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9113, 0.0963, 148.2],
+              "alpha": 1.0,
+              "hex": "#B6F4BE"
+            }
+          },
+          "950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9517, 0.0402, 147.62],
+              "alpha": 1.0,
+              "hex": "#DEF7E0"
+            }
+          },
+          "975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9692, 0.0158, 148.69],
+              "alpha": 1.0,
+              "hex": "#EEF8EF"
+            }
+          },
+          "A25": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2045, 0.0592, 148.0],
+              "alpha": 0.7895,
+              "hex": "#001E06C9"
+            }
+          },
+          "A50": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.2413, 0.0706, 147.58],
+              "alpha": 0.6316,
+              "hex": "#002809A1"
+            }
+          },
+          "A100": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.3611, 0.1114, 145.68],
+              "alpha": 0.4211,
+              "hex": "#004C126B"
+            }
+          },
+          "A200": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8718, 0.2677, 144.66],
+              "alpha": 0.1923,
+              "hex": "#27FF4D31"
+            }
+          },
+          "A300": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8767, 0.2471, 146.42],
+              "alpha": 0.3077,
+              "hex": "#3AFF674E"
+            }
+          },
+          "A400": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8817, 0.2304, 147.57],
+              "alpha": 0.4145,
+              "hex": "#4AFF776A"
+            }
+          },
+          "A500": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8858, 0.2199, 147.74],
+              "alpha": 0.5513,
+              "hex": "#58FF7F8D"
+            }
+          },
+          "A600": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8887, 0.2117, 148.15],
+              "alpha": 0.6667,
+              "hex": "#5FFF85AA"
+            }
+          },
+          "A700": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.8911, 0.2046, 148.68],
+              "alpha": 0.7821,
+              "hex": "#65FF8BC7"
+            }
+          },
+          "A800": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9084, 0.1682, 147.94],
+              "alpha": 0.8803,
+              "hex": "#8BFF9FE0"
+            }
+          },
+          "A900": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9419, 0.1003, 148.06],
+              "alpha": 0.953,
+              "hex": "#BEFFC6F3"
+            }
+          },
+          "A950": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9749, 0.0415, 147.38],
+              "alpha": 0.9658,
+              "hex": "#E5FFE7F6"
+            }
+          },
+          "A975": {
+            "type": "color",
+            "value": {
+              "colorSpace": "oklch",
+              "components": [0.9898, 0.0163, 148.14],
+              "alpha": 0.9701,
+              "hex": "#F5FFF6F7"
+            }
+          }
         }
       }
     }

--- a/tokens/deprecated/base/palette.json
+++ b/tokens/deprecated/base/palette.json
@@ -1175,6 +1175,29 @@
         "deprecated": true,
         "deprecatedComment": "replace cappuccino600 with appropriate replacement color"
       }
+    },
+    "neutral": {
+      "0": {
+        "value": "#FFFFFF",
+        "type": "color",
+        "deprecated": true,
+        "deprecatedComment": "replace neutral0 with {palette.white.$root}",
+        "fallback": "{palette.white.$root}"
+      },
+      "1000": {
+        "value": "#000000",
+        "type": "color",
+        "deprecated": true,
+        "deprecatedComment": "replace neutral1000 with {palette.black.$root}",
+        "fallback": "{palette.black.$root}"
+      },
+      "A0": {
+        "value": "#00000000",
+        "type": "color",
+        "deprecated": true,
+        "deprecatedComment": "replace neutralA0 with {palette.black.A0}",
+        "fallback": "{palette.black.A0}"
+      }
     }
   },
   "extended": {

--- a/tokens/sys/brand/canvas.json
+++ b/tokens/sys/brand/canvas.json
@@ -3,38 +3,31 @@
     "primary": {
       "25": {
         "value": "{palette.blue.25}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "50": {
         "value": "{palette.blue.50}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "100": {
         "value": "{palette.blue.100}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "200": {
         "value": "{palette.blue.200}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "300": {
         "value": "{palette.blue.300}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "400": {
         "value": "{palette.blue.400}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "500": {
         "value": "{palette.blue.500}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "600": {
         "value": "{palette.blue.600}",
@@ -43,28 +36,23 @@
       },
       "700": {
         "value": "{palette.blue.700}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "800": {
         "value": "{palette.blue.800}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "900": {
         "value": "{palette.blue.900}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "950": {
         "value": "{palette.blue.950}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "975": {
         "value": "{palette.blue.975}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "A25": {
         "value": "{palette.blue.A25}",
@@ -81,209 +69,72 @@
       "A200": {
         "value": "{palette.blue.A200}",
         "type": "color"
-      }
-    },
-    "critical": {
-      "25": {
-        "value": "{palette.red.25}",
+      },
+      "A300": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A300}"
       },
-      "50": {
-        "value": "{palette.red.50}",
+      "A400": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A400}"
       },
-      "100": {
-        "value": "{palette.red.100}",
+      "A500": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A500}"
       },
-      "200": {
-        "value": "{palette.red.200}",
+      "A600": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A600}"
       },
-      "300": {
-        "value": "{palette.red.300}",
+      "A700": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A700}"
       },
-      "400": {
-        "value": "{palette.red.400}",
+      "A800": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A800}"
       },
-      "500": {
-        "value": "{palette.red.500}",
+      "A900": {
         "type": "color",
-        "description": ""
+        "value": "{palette.blue.A900}"
       },
-      "600": {
-        "value": "{palette.red.600}",
+      "A950": {
         "type": "color",
-        "description": "Base critical color. Use fg.inverse on this."
+        "value": "{palette.blue.A950}"
       },
-      "700": {
-        "value": "{palette.red.700}",
+      "A975": {
         "type": "color",
-        "description": ""
-      },
-      "800": {
-        "value": "{palette.red.800}",
-        "type": "color",
-        "description": ""
-      },
-      "900": {
-        "value": "{palette.red.900}",
-        "type": "color",
-        "description": ""
-      },
-      "950": {
-        "value": "{palette.red.950}",
-        "type": "color",
-        "description": ""
-      },
-      "975": {
-        "value": "{palette.red.975}",
-        "type": "color",
-        "description": ""
-      },
-      "A25": {
-        "value": "{palette.red.A25}",
-        "type": "color"
-      },
-      "A50": {
-        "value": "{palette.red.A50}",
-        "type": "color"
-      },
-      "A100": {
-        "value": "{palette.red.A100}",
-        "type": "color"
-      },
-      "A200": {
-        "value": "{palette.red.A200}",
-        "type": "color"
-      }
-    },
-    "caution": {
-      "25": {
-        "value": "{palette.amber.25}",
-        "type": "color",
-        "description": ""
-      },
-      "50": {
-        "value": "{palette.amber.50}",
-        "type": "color",
-        "description": ""
-      },
-      "100": {
-        "value": "{palette.amber.100}",
-        "type": "color",
-        "description": ""
-      },
-      "200": {
-        "value": "{palette.amber.200}",
-        "type": "color",
-        "description": ""
-      },
-      "300": {
-        "value": "{palette.amber.300}",
-        "type": "color",
-        "description": ""
-      },
-      "400": {
-        "value": "{palette.amber.400}",
-        "type": "color",
-        "description": "Base caution color (amber.400). Use fg.contrast on this."
-      },
-      "500": {
-        "value": "{palette.amber.500}",
-        "type": "color",
-        "description": ""
-      },
-      "600": {
-        "value": "{palette.amber.600}",
-        "type": "color",
-        "description": ""
-      },
-      "700": {
-        "value": "{palette.amber.700}",
-        "type": "color",
-        "description": ""
-      },
-      "800": {
-        "value": "{palette.amber.800}",
-        "type": "color",
-        "description": ""
-      },
-      "900": {
-        "value": "{palette.amber.900}",
-        "type": "color",
-        "description": ""
-      },
-      "950": {
-        "value": "{palette.amber.950}",
-        "type": "color",
-        "description": ""
-      },
-      "975": {
-        "value": "{palette.amber.975}",
-        "type": "color",
-        "description": ""
-      },
-      "A25": {
-        "value": "{palette.amber.A25}",
-        "type": "color"
-      },
-      "A50": {
-        "value": "{palette.amber.A50}",
-        "type": "color"
-      },
-      "A100": {
-        "value": "{palette.amber.A100}",
-        "type": "color"
-      },
-      "A200": {
-        "value": "{palette.amber.A200}",
-        "type": "color"
+        "value": "{palette.blue.A975}"
       }
     },
     "positive": {
       "25": {
         "value": "{palette.green.25}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "50": {
         "value": "{palette.green.50}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "100": {
         "value": "{palette.green.100}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "200": {
         "value": "{palette.green.200}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "300": {
         "value": "{palette.green.300}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "400": {
         "value": "{palette.green.400}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "500": {
         "value": "{palette.green.500}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "600": {
         "value": "{palette.green.600}",
@@ -292,28 +143,23 @@
       },
       "700": {
         "value": "{palette.green.700}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "800": {
         "value": "{palette.green.800}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "900": {
         "value": "{palette.green.900}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "950": {
         "value": "{palette.green.950}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "975": {
         "value": "{palette.green.975}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "A25": {
         "value": "{palette.green.A25}",
@@ -330,73 +176,310 @@
       "A200": {
         "value": "{palette.green.A200}",
         "type": "color"
+      },
+      "A300": {
+        "type": "color",
+        "value": "{palette.green.A300}"
+      },
+      "A400": {
+        "type": "color",
+        "value": "{palette.green.A400}"
+      },
+      "A500": {
+        "type": "color",
+        "value": "{palette.green.A500}"
+      },
+      "A600": {
+        "type": "color",
+        "value": "{palette.green.A600}"
+      },
+      "A700": {
+        "type": "color",
+        "value": "{palette.green.A700}"
+      },
+      "A800": {
+        "type": "color",
+        "value": "{palette.green.A800}"
+      },
+      "A900": {
+        "type": "color",
+        "value": "{palette.green.A900}"
+      },
+      "A950": {
+        "type": "color",
+        "value": "{palette.green.A950}"
+      },
+      "A975": {
+        "type": "color",
+        "value": "{palette.green.A975}"
+      }
+    },
+    "caution": {
+      "25": {
+        "value": "{palette.amber.25}",
+        "type": "color"
+      },
+      "50": {
+        "value": "{palette.amber.50}",
+        "type": "color"
+      },
+      "100": {
+        "value": "{palette.amber.100}",
+        "type": "color"
+      },
+      "200": {
+        "value": "{palette.amber.200}",
+        "type": "color"
+      },
+      "300": {
+        "value": "{palette.amber.300}",
+        "type": "color"
+      },
+      "400": {
+        "value": "{palette.amber.400}",
+        "type": "color",
+        "description": "Base caution color (amber.400). Use fg.contrast on this."
+      },
+      "500": {
+        "value": "{palette.amber.500}",
+        "type": "color"
+      },
+      "600": {
+        "value": "{palette.amber.600}",
+        "type": "color"
+      },
+      "700": {
+        "value": "{palette.amber.700}",
+        "type": "color"
+      },
+      "800": {
+        "value": "{palette.amber.800}",
+        "type": "color"
+      },
+      "900": {
+        "value": "{palette.amber.900}",
+        "type": "color"
+      },
+      "950": {
+        "value": "{palette.amber.950}",
+        "type": "color"
+      },
+      "975": {
+        "value": "{palette.amber.975}",
+        "type": "color"
+      },
+      "A25": {
+        "value": "{palette.amber.A25}",
+        "type": "color"
+      },
+      "A50": {
+        "value": "{palette.amber.A50}",
+        "type": "color"
+      },
+      "A100": {
+        "value": "{palette.amber.A100}",
+        "type": "color"
+      },
+      "A200": {
+        "value": "{palette.amber.A200}",
+        "type": "color"
+      },
+      "A300": {
+        "type": "color",
+        "value": "{palette.amber.A300}"
+      },
+      "A400": {
+        "type": "color",
+        "value": "{palette.amber.A400}"
+      },
+      "A500": {
+        "type": "color",
+        "value": "{palette.amber.A500}"
+      },
+      "A600": {
+        "type": "color",
+        "value": "{palette.amber.A600}"
+      },
+      "A700": {
+        "type": "color",
+        "value": "{palette.amber.A700}"
+      },
+      "A800": {
+        "type": "color",
+        "value": "{palette.amber.A800}"
+      },
+      "A900": {
+        "type": "color",
+        "value": "{palette.amber.A900}"
+      },
+      "A950": {
+        "type": "color",
+        "value": "{palette.amber.A950}"
+      },
+      "A975": {
+        "type": "color",
+        "value": "{palette.amber.A975}"
+      }
+    },
+    "critical": {
+      "25": {
+        "value": "{palette.red.25}",
+        "type": "color"
+      },
+      "50": {
+        "value": "{palette.red.50}",
+        "type": "color"
+      },
+      "100": {
+        "value": "{palette.red.100}",
+        "type": "color"
+      },
+      "200": {
+        "value": "{palette.red.200}",
+        "type": "color"
+      },
+      "300": {
+        "value": "{palette.red.300}",
+        "type": "color"
+      },
+      "400": {
+        "value": "{palette.red.400}",
+        "type": "color"
+      },
+      "500": {
+        "value": "{palette.red.500}",
+        "type": "color"
+      },
+      "600": {
+        "value": "{palette.red.600}",
+        "type": "color",
+        "description": "Base critical color. Use fg.inverse on this."
+      },
+      "700": {
+        "value": "{palette.red.700}",
+        "type": "color"
+      },
+      "800": {
+        "value": "{palette.red.800}",
+        "type": "color"
+      },
+      "900": {
+        "value": "{palette.red.900}",
+        "type": "color"
+      },
+      "950": {
+        "value": "{palette.red.950}",
+        "type": "color"
+      },
+      "975": {
+        "value": "{palette.red.975}",
+        "type": "color"
+      },
+      "A25": {
+        "value": "{palette.red.A25}",
+        "type": "color"
+      },
+      "A50": {
+        "value": "{palette.red.A50}",
+        "type": "color"
+      },
+      "A100": {
+        "value": "{palette.red.A100}",
+        "type": "color"
+      },
+      "A200": {
+        "value": "{palette.red.A200}",
+        "type": "color"
+      },
+      "A300": {
+        "type": "color",
+        "value": "{palette.red.A300}"
+      },
+      "A400": {
+        "type": "color",
+        "value": "{palette.red.A400}"
+      },
+      "A500": {
+        "type": "color",
+        "value": "{palette.red.A500}"
+      },
+      "A600": {
+        "type": "color",
+        "value": "{palette.red.A600}"
+      },
+      "A700": {
+        "type": "color",
+        "value": "{palette.red.A700}"
+      },
+      "A800": {
+        "type": "color",
+        "value": "{palette.red.A800}"
+      },
+      "A900": {
+        "type": "color",
+        "value": "{palette.red.A900}"
+      },
+      "A950": {
+        "type": "color",
+        "value": "{palette.red.A950}"
+      },
+      "A975": {
+        "type": "color",
+        "value": "{palette.red.A975}"
       }
     },
     "neutral": {
       "25": {
         "value": "{palette.slate.25}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "50": {
         "value": "{palette.slate.50}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "100": {
         "value": "{palette.slate.100}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "200": {
         "value": "{palette.slate.200}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "300": {
         "value": "{palette.slate.300}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "400": {
         "value": "{palette.slate.400}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "500": {
         "value": "{palette.slate.500}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "600": {
         "value": "{palette.slate.600}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "700": {
         "value": "{palette.slate.700}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "800": {
         "value": "{palette.slate.800}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "900": {
         "value": "{palette.slate.900}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "950": {
         "value": "{palette.slate.950}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "975": {
         "value": "{palette.slate.975}",
-        "type": "color",
-        "description": ""
+        "type": "color"
       },
       "A25": {
         "value": "{palette.slate.A25}",
@@ -409,6 +492,10 @@
       "A100": {
         "value": "{palette.slate.A100}",
         "type": "color"
+      },
+      "A150": {
+        "type": "color",
+        "value": "{palette.slate.A150}"
       },
       "A200": {
         "value": "{palette.slate.A200}",
@@ -438,6 +525,10 @@
         "value": "{palette.slate.A800}",
         "type": "color"
       },
+      "A850": {
+        "type": "color",
+        "value": "{palette.slate.A850}"
+      },
       "A900": {
         "value": "{palette.slate.A900}",
         "type": "color"
@@ -448,6 +539,59 @@
       },
       "A975": {
         "value": "{palette.slate.A975}",
+        "type": "color"
+      }
+    },
+    "action": {
+      "$root": {
+        "value": "{palette.blue.600}",
+        "type": "color",
+        "description": "Base action color"
+      },
+      "lightest": {
+        "value": "{palette.blue.25}",
+        "type": "color",
+        "description": "Lightest action color"
+      },
+      "lighter": {
+        "value": "{palette.blue.50}",
+        "type": "color",
+        "description": "Lightest action color"
+      },
+      "light": {
+        "value": "{palette.blue.200}",
+        "type": "color",
+        "description": "Light action color"
+      },
+      "dark": {
+        "value": "{palette.blue.700}",
+        "type": "color",
+        "description": "Dark action color"
+      },
+      "darker": {
+        "value": "{palette.blue.800}",
+        "type": "color",
+        "description": "Dark action color"
+      },
+      "darkest": {
+        "value": "{palette.blue.950}",
+        "type": "color",
+        "description": "Darkest action color"
+      },
+      "accent": {
+        "value": "{palette.neutral.0}",
+        "type": "color",
+        "description": "Foreground color in actions"
+      },
+      "base": {
+        "value": "{palette.blue.600}",
+        "type": "color",
+        "description": "Base action color"
+      }
+    },
+    "gradient": {
+      "primary": {
+        "value": "linear-gradient(90deg, {brand.primary.base} 0%, {brand.primary.dark} 100%)",
         "type": "color"
       }
     },
@@ -470,53 +614,591 @@
           "type": "color"
         }
       }
-    },
-    "action": {
-      "base": {
-        "value": "{palette.blue.600}",
-        "type": "color",
-        "description": "Base action color"
-      },
-      "lightest": {
-        "value": "{palette.blue.25}",
-        "type": "color",
-        "description": "Lightest action color"
-      },
-      "light": {
-        "value": "{palette.blue.200}",
-        "type": "color",
-        "description": "Light action color"
-      },
-      "darkest": {
-        "value": "{palette.blue.950}",
-        "type": "color",
-        "description": "Darkest action color"
-      },
-      "dark": {
-        "value": "{palette.blue.700}",
-        "type": "color",
-        "description": "Dark action color"
-      },
-      "accent": {
-        "value": "{palette.neutral.0}",
-        "type": "color",
-        "description": "Foreground color in actions"
-      },
-      "darker": {
-        "value": "{palette.blue.800}",
-        "type": "color",
-        "description": "Dark action color"
-      },
-      "lighter": {
-        "value": "{palette.blue.50}",
-        "type": "color",
-        "description": "Lightest action color"
-      }
-    },
-    "gradient": {
+    }
+  },
+  "dark": {
+    "brand": {
       "primary": {
-        "value": "linear-gradient(90deg, {brand.primary.base} 0%, {brand.primary.dark} 100%)",
-        "type": "color"
+        "25": {
+          "type": "color",
+          "value": "{dark.blue.25}"
+        },
+        "50": {
+          "type": "color",
+          "value": "{dark.blue.50}"
+        },
+        "100": {
+          "type": "color",
+          "value": "{dark.blue.100}"
+        },
+        "200": {
+          "type": "color",
+          "value": "{dark.blue.200}"
+        },
+        "300": {
+          "type": "color",
+          "value": "{dark.blue.300}"
+        },
+        "400": {
+          "type": "color",
+          "value": "{dark.blue.400}"
+        },
+        "500": {
+          "type": "color",
+          "value": "{dark.blue.500}"
+        },
+        "600": {
+          "type": "color",
+          "value": "{dark.blue.600}"
+        },
+        "700": {
+          "type": "color",
+          "value": "{dark.blue.700}"
+        },
+        "800": {
+          "type": "color",
+          "value": "{dark.blue.800}"
+        },
+        "900": {
+          "type": "color",
+          "value": "{dark.blue.900}"
+        },
+        "950": {
+          "type": "color",
+          "value": "{dark.blue.950}"
+        },
+        "975": {
+          "type": "color",
+          "value": "{dark.blue.975}"
+        },
+        "A25": {
+          "type": "color",
+          "value": "{dark.blue.A25}"
+        },
+        "A50": {
+          "type": "color",
+          "value": "{dark.blue.A50}"
+        },
+        "A100": {
+          "type": "color",
+          "value": "{dark.blue.A100}"
+        },
+        "A200": {
+          "type": "color",
+          "value": "{dark.blue.A200}"
+        },
+        "A300": {
+          "type": "color",
+          "value": "{dark.blue.A300}"
+        },
+        "A400": {
+          "type": "color",
+          "value": "{dark.blue.A400}"
+        },
+        "A500": {
+          "type": "color",
+          "value": "{dark.blue.A500}"
+        },
+        "A600": {
+          "type": "color",
+          "value": "{dark.blue.A600}"
+        },
+        "A700": {
+          "type": "color",
+          "value": "{dark.blue.A700}"
+        },
+        "A800": {
+          "type": "color",
+          "value": "{dark.blue.A800}"
+        },
+        "A900": {
+          "type": "color",
+          "value": "{dark.blue.A900}"
+        },
+        "A950": {
+          "type": "color",
+          "value": "{dark.blue.A950}"
+        },
+        "A975": {
+          "type": "color",
+          "value": "{dark.blue.A975}"
+        }
+      },
+      "positive": {
+        "25": {
+          "type": "color",
+          "value": "{dark.green.25}"
+        },
+        "50": {
+          "type": "color",
+          "value": "{dark.green.50}"
+        },
+        "100": {
+          "type": "color",
+          "value": "{dark.green.100}"
+        },
+        "200": {
+          "type": "color",
+          "value": "{dark.green.200}"
+        },
+        "300": {
+          "type": "color",
+          "value": "{dark.green.300}"
+        },
+        "400": {
+          "type": "color",
+          "value": "{dark.green.400}"
+        },
+        "500": {
+          "type": "color",
+          "value": "{dark.green.500}"
+        },
+        "600": {
+          "type": "color",
+          "value": "{dark.green.600}"
+        },
+        "700": {
+          "type": "color",
+          "value": "{dark.green.700}"
+        },
+        "800": {
+          "type": "color",
+          "value": "{dark.green.800}"
+        },
+        "900": {
+          "type": "color",
+          "value": "{dark.green.900}"
+        },
+        "950": {
+          "type": "color",
+          "value": "{dark.green.950}"
+        },
+        "975": {
+          "type": "color",
+          "value": "{dark.green.975}"
+        },
+        "A25": {
+          "type": "color",
+          "value": "{dark.green.A25}"
+        },
+        "A50": {
+          "type": "color",
+          "value": "{dark.green.A50}"
+        },
+        "A100": {
+          "type": "color",
+          "value": "{dark.green.A100}"
+        },
+        "A200": {
+          "type": "color",
+          "value": "{dark.green.A200}"
+        },
+        "A300": {
+          "type": "color",
+          "value": "{dark.green.A300}"
+        },
+        "A400": {
+          "type": "color",
+          "value": "{dark.green.A400}"
+        },
+        "A500": {
+          "type": "color",
+          "value": "{dark.green.A500}"
+        },
+        "A600": {
+          "type": "color",
+          "value": "{dark.green.A600}"
+        },
+        "A700": {
+          "type": "color",
+          "value": "{dark.green.A700}"
+        },
+        "A800": {
+          "type": "color",
+          "value": "{dark.green.A800}"
+        },
+        "A900": {
+          "type": "color",
+          "value": "{dark.green.A900}"
+        },
+        "A950": {
+          "type": "color",
+          "value": "{dark.green.A950}"
+        },
+        "A975": {
+          "type": "color",
+          "value": "{dark.green.A975}"
+        }
+      },
+      "caution": {
+        "25": {
+          "type": "color",
+          "value": "{dark.amber.25}"
+        },
+        "50": {
+          "type": "color",
+          "value": "{dark.amber.50}"
+        },
+        "100": {
+          "type": "color",
+          "value": "{dark.amber.100}"
+        },
+        "200": {
+          "type": "color",
+          "value": "{dark.amber.200}"
+        },
+        "300": {
+          "type": "color",
+          "value": "{dark.amber.300}"
+        },
+        "400": {
+          "type": "color",
+          "value": "{dark.amber.400}"
+        },
+        "500": {
+          "type": "color",
+          "value": "{dark.amber.500}"
+        },
+        "600": {
+          "type": "color",
+          "value": "{dark.amber.600}"
+        },
+        "700": {
+          "type": "color",
+          "value": "{dark.amber.700}"
+        },
+        "800": {
+          "type": "color",
+          "value": "{dark.amber.800}"
+        },
+        "900": {
+          "type": "color",
+          "value": "{dark.amber.900}"
+        },
+        "950": {
+          "type": "color",
+          "value": "{dark.amber.950}"
+        },
+        "975": {
+          "type": "color",
+          "value": "{dark.amber.975}"
+        },
+        "A25": {
+          "type": "color",
+          "value": "{dark.amber.A25}"
+        },
+        "A50": {
+          "type": "color",
+          "value": "{dark.amber.A50}"
+        },
+        "A100": {
+          "type": "color",
+          "value": "{dark.amber.A100}"
+        },
+        "A200": {
+          "type": "color",
+          "value": "{dark.amber.A200}"
+        },
+        "A300": {
+          "type": "color",
+          "value": "{dark.amber.A300}"
+        },
+        "A400": {
+          "type": "color",
+          "value": "{dark.amber.A400}"
+        },
+        "A500": {
+          "type": "color",
+          "value": "{dark.amber.A500}"
+        },
+        "A600": {
+          "type": "color",
+          "value": "{dark.amber.A600}"
+        },
+        "A700": {
+          "type": "color",
+          "value": "{dark.amber.A700}"
+        },
+        "A800": {
+          "type": "color",
+          "value": "{dark.amber.A800}"
+        },
+        "A900": {
+          "type": "color",
+          "value": "{dark.amber.A900}"
+        },
+        "A950": {
+          "type": "color",
+          "value": "{dark.amber.A950}"
+        },
+        "A975": {
+          "type": "color",
+          "value": "{dark.amber.A975}"
+        }
+      },
+      "critical": {
+        "25": {
+          "type": "color",
+          "value": "{dark.red.25}"
+        },
+        "50": {
+          "type": "color",
+          "value": "{dark.red.50}"
+        },
+        "100": {
+          "type": "color",
+          "value": "{dark.red.100}"
+        },
+        "200": {
+          "type": "color",
+          "value": "{dark.red.200}"
+        },
+        "300": {
+          "type": "color",
+          "value": "{dark.red.300}"
+        },
+        "400": {
+          "type": "color",
+          "value": "{dark.red.400}"
+        },
+        "500": {
+          "type": "color",
+          "value": "{dark.red.500}"
+        },
+        "600": {
+          "type": "color",
+          "value": "{dark.red.600}"
+        },
+        "700": {
+          "type": "color",
+          "value": "{dark.red.700}"
+        },
+        "800": {
+          "type": "color",
+          "value": "{dark.red.800}"
+        },
+        "900": {
+          "type": "color",
+          "value": "{dark.red.900}"
+        },
+        "950": {
+          "type": "color",
+          "value": "{dark.red.950}"
+        },
+        "975": {
+          "type": "color",
+          "value": "{dark.red.975}"
+        },
+        "A25": {
+          "type": "color",
+          "value": "{dark.red.A25}"
+        },
+        "A50": {
+          "type": "color",
+          "value": "{dark.red.A50}"
+        },
+        "A100": {
+          "type": "color",
+          "value": "{dark.red.A100}"
+        },
+        "A200": {
+          "type": "color",
+          "value": "{dark.red.A200}"
+        },
+        "A300": {
+          "type": "color",
+          "value": "{dark.red.A300}"
+        },
+        "A400": {
+          "type": "color",
+          "value": "{dark.red.A400}"
+        },
+        "A500": {
+          "type": "color",
+          "value": "{dark.red.A500}"
+        },
+        "A600": {
+          "type": "color",
+          "value": "{dark.red.A600}"
+        },
+        "A700": {
+          "type": "color",
+          "value": "{dark.red.A700}"
+        },
+        "A800": {
+          "type": "color",
+          "value": "{dark.red.A800}"
+        },
+        "A900": {
+          "type": "color",
+          "value": "{dark.red.A900}"
+        },
+        "A950": {
+          "type": "color",
+          "value": "{dark.red.A950}"
+        },
+        "A975": {
+          "type": "color",
+          "value": "{dark.red.A975}"
+        }
+      },
+      "neutral": {
+        "25": {
+          "type": "color",
+          "value": "{dark.slate.25}"
+        },
+        "50": {
+          "type": "color",
+          "value": "{dark.slate.50}"
+        },
+        "100": {
+          "type": "color",
+          "value": "{dark.slate.100}"
+        },
+        "150": {
+          "type": "color",
+          "value": "{dark.slate.150}"
+        },
+        "200": {
+          "type": "color",
+          "value": "{dark.slate.200}"
+        },
+        "300": {
+          "type": "color",
+          "value": "{dark.slate.300}"
+        },
+        "400": {
+          "type": "color",
+          "value": "{dark.slate.400}"
+        },
+        "500": {
+          "type": "color",
+          "value": "{dark.slate.500}"
+        },
+        "600": {
+          "type": "color",
+          "value": "{dark.slate.600}"
+        },
+        "700": {
+          "type": "color",
+          "value": "{dark.slate.700}"
+        },
+        "800": {
+          "type": "color",
+          "value": "{dark.slate.800}"
+        },
+        "900": {
+          "type": "color",
+          "value": "{dark.slate.900}"
+        },
+        "950": {
+          "type": "color",
+          "value": "{dark.slate.950}"
+        },
+        "975": {
+          "type": "color",
+          "value": "{dark.slate.975}"
+        },
+        "A25": {
+          "type": "color",
+          "value": "{dark.slate.A25}"
+        },
+        "A50": {
+          "type": "color",
+          "value": "{dark.slate.A50}"
+        },
+        "A100": {
+          "type": "color",
+          "value": "{dark.slate.A100}"
+        },
+        "A150": {
+          "type": "color",
+          "value": "{dark.slate.A150}"
+        },
+        "A200": {
+          "type": "color",
+          "value": "{dark.slate.A200}"
+        },
+        "A300": {
+          "type": "color",
+          "value": "{dark.slate.A300}"
+        },
+        "A400": {
+          "type": "color",
+          "value": "{dark.slate.A400}"
+        },
+        "A500": {
+          "type": "color",
+          "value": "{dark.slate.A500}"
+        },
+        "A600": {
+          "type": "color",
+          "value": "{dark.slate.A600}"
+        },
+        "A700": {
+          "type": "color",
+          "value": "{dark.slate.A700}"
+        },
+        "A800": {
+          "type": "color",
+          "value": "{dark.slate.A800}"
+        },
+        "A850": {
+          "type": "color",
+          "value": "{dark.slate.A850}"
+        },
+        "A900": {
+          "type": "color",
+          "value": "{dark.slate.A900}"
+        },
+        "A950": {
+          "type": "color",
+          "value": "{dark.slate.A950}"
+        },
+        "A975": {
+          "type": "color",
+          "value": "{dark.slate.A975}"
+        }
+      },
+      "action": {
+        "$root": {
+          "type": "color",
+          "value": "{dark.brand.primary.600}"
+        },
+        "lightest": {
+          "type": "color",
+          "value": "{dark.brand.primary.25}"
+        },
+        "lighter": {
+          "type": "color",
+          "value": "{dark.brand.primary.50}"
+        },
+        "light": {
+          "type": "color",
+          "value": "{dark.brand.primary.200}"
+        },
+        "dark": {
+          "type": "color",
+          "value": "{dark.brand.primary.700}"
+        },
+        "darker": {
+          "type": "color",
+          "value": "{dark.brand.primary.800}"
+        },
+        "darkest": {
+          "type": "color",
+          "value": "{dark.brand.primary.950}"
+        },
+        "accent": {
+          "type": "color",
+          "value": "{palette.black.$root}"
+        }
+      },
+      "gradient": {
+        "primary": {
+          "type": "color",
+          "value": "linear-gradient(to right in oklab, {dark.brand.primary.600} 0%, {dark.brand.primary.800} 100%)"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Adds dark palette to base.json
- Add dark alpha to base.json, with dark.slate.25 as the base.
- Adds global white and black + alphas
- Deprecates neutral/0, 1000, and A0 (points to white/black/A0 instead)