### PR TITLE
feat: Add Sana surface text-highlight

### DIFF
--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1946,6 +1946,148 @@
         "type": "text"
       }
     },
+    "type": {
+      "subtext": {
+        "sm": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.subtext.sm}",
+            "fontSize": "{font-size.subtext.sm}",
+            "letterSpacing": "{letter-spacing.subtext.sm}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.subtext.small"}
+        },
+        "md": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.subtext.md}",
+            "fontSize": "{font-size.subtext.md}",
+            "letterSpacing": "{letter-spacing.subtext.md}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.subtext.medium"}
+        },
+        "lg": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.subtext.lg}",
+            "fontSize": "{font-size.subtext.lg}",
+            "letterSpacing": "{letter-spacing.subtext.lg}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.subtext.large"}
+        }
+      },
+      "body": {
+        "sm": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.body.sm}",
+            "fontSize": "{font-size.body.sm}",
+            "letterSpacing": "{letter-spacing.body.sm}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.body.small"}
+        },
+        "md": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.body.md}",
+            "fontSize": "{font-size.body.md}",
+            "letterSpacing": "{letter-spacing.body.md}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.body.medium"}
+        },
+        "lg": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.normal}",
+            "lineHeight": "{line-height.body.lg}",
+            "fontSize": "{font-size.body.lg}",
+            "letterSpacing": "{letter-spacing.body.lg}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.body.large"}
+        }
+      },
+      "heading": {
+        "sm": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.heading.sm}",
+            "fontSize": "{font-size.heading.sm}",
+            "letterSpacing": "{letter-spacing.heading.sm}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.heading.small"}
+        },
+        "md": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.heading.md}",
+            "fontSize": "{font-size.heading.md}",
+            "letterSpacing": "{letter-spacing.heading.md}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.heading.medium"}
+        },
+        "lg": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.heading.lg}",
+            "fontSize": "{font-size.heading.lg}",
+            "letterSpacing": "{letter-spacing.heading.lg}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.heading.large"}
+        }
+      },
+      "title": {
+        "sm": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.title.sm}",
+            "fontSize": "{font-size.title.sm}",
+            "letterSpacing": "{letter-spacing.title.sm}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.title.small"}
+        },
+        "md": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.title.md}",
+            "fontSize": "{font-size.title.md}",
+            "letterSpacing": "{letter-spacing.title.md}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.title.medium"}
+        },
+        "lg": {
+          "value": {
+            "fontFamily": "{font-family.default}",
+            "fontWeight": "{font-weight.bold}",
+            "lineHeight": "{line-height.title.lg}",
+            "fontSize": "{font-size.title.lg}",
+            "letterSpacing": "{letter-spacing.title.lg}"
+          },
+          "type": "typography",
+          "deprecatedValues": {"v3": "sys.type.title.large"}
+        }
+      }
+    },
     "color": {
       "color": {
         "bg": {

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -2156,6 +2156,11 @@
               "description": "Stronger high contrast dark container background"
             }
           },
+          "text-highlight": {
+            "value": "{base.palette.indigo.A200}",
+            "type": "color",
+            "description": "Background highlight for selected text in body copy"
+          },
           "danger": {
             "default": {
               "value": "{brand.critical.A25}",

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1947,144 +1947,58 @@
       }
     },
     "type": {
-      "subtext": {
-        "sm": {
-          "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.subtext.sm}",
-            "fontSize": "{font-size.subtext.sm}",
-            "letterSpacing": "{letter-spacing.subtext.sm}"
-          },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.subtext.small"}
-        },
-        "md": {
-          "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.subtext.md}",
-            "fontSize": "{font-size.subtext.md}",
-            "letterSpacing": "{letter-spacing.subtext.md}"
-          },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.subtext.medium"}
-        },
-        "lg": {
-          "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.subtext.lg}",
-            "fontSize": "{font-size.subtext.lg}",
-            "letterSpacing": "{letter-spacing.subtext.lg}"
-          },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.subtext.large"}
-        }
-      },
       "body": {
-        "sm": {
-          "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.body.sm}",
-            "fontSize": "{font-size.body.sm}",
-            "letterSpacing": "{letter-spacing.body.sm}"
-          },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.body.small"}
-        },
         "md": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.body.md}",
-            "fontSize": "{font-size.body.md}",
             "letterSpacing": "{letter-spacing.body.md}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.body.medium"}
+          "type": "typography"
         },
         "lg": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.normal}",
-            "lineHeight": "{line-height.body.lg}",
-            "fontSize": "{font-size.body.lg}",
             "letterSpacing": "{letter-spacing.body.lg}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.body.large"}
+          "type": "typography"
         }
       },
       "heading": {
         "sm": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.heading.sm}",
-            "fontSize": "{font-size.heading.sm}",
             "letterSpacing": "{letter-spacing.heading.sm}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.heading.small"}
+          "type": "typography"
         },
         "md": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.heading.md}",
-            "fontSize": "{font-size.heading.md}",
             "letterSpacing": "{letter-spacing.heading.md}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.heading.medium"}
+          "type": "typography"
         },
         "lg": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.heading.lg}",
-            "fontSize": "{font-size.heading.lg}",
             "letterSpacing": "{letter-spacing.heading.lg}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.heading.large"}
+          "type": "typography"
         }
       },
       "title": {
         "sm": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.title.sm}",
-            "fontSize": "{font-size.title.sm}",
             "letterSpacing": "{letter-spacing.title.sm}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.title.small"}
+          "type": "typography"
         },
         "md": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.title.md}",
-            "fontSize": "{font-size.title.md}",
             "letterSpacing": "{letter-spacing.title.md}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.title.medium"}
+          "type": "typography"
         },
         "lg": {
           "value": {
-            "fontFamily": "{font-family.default}",
-            "fontWeight": "{font-weight.bold}",
-            "lineHeight": "{line-height.title.lg}",
-            "fontSize": "{font-size.title.lg}",
             "letterSpacing": "{letter-spacing.title.lg}"
           },
-          "type": "typography",
-          "deprecatedValues": {"v3": "sys.type.title.large"}
+          "type": "typography"
         }
       }
     },


### PR DESCRIPTION
- **Add Sana type style composites with letter-spacing 1–12 mapping Define sys.type typography tokens for subtext, body, heading, and title sizes in the Sana theme, using the Sana letter-spacing scale instead of Canvas 50/100/150/200.**
- **fix: Removing shared properties in composite type token**
- **feat: Add surface text-highlight for ::selection**
