### PR TITLE
feat: Add fg link tokens

### DIFF
--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -2488,6 +2488,18 @@
             "description": "Stronger informational text and icons"
           }
         },
+        "link": {
+          "default": {
+            "value": "{base.palette.blue.600}",
+            "type": "color",
+            "description": "Default text color for hyperlinks"
+          },
+          "hover": {
+            "value": "{base.palette.blue.700}",
+            "type": "color",
+            "description": "Text color for hyperlinks on hover"
+          }
+        },
         "ai": {
           "value": "{base.palette.blue.950}",
           "type": "color",


### PR DESCRIPTION
Add  `color.fg.link.default` and `color.fg.link.hover` to `sana.json` theme. This color should be used for standalone hyperlinks.