### PR TITLE
chore: Update all external actions to use SHA1 for versioning

### DIFF
--- a/.github/workflows/forward-merge.yml
+++ b/.github/workflows/forward-merge.yml
@@ -44,7 +44,7 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{needs.get-branch-names.outputs.next-branch}} # checkout the next branch
@@ -58,7 +58,7 @@ jobs:
 
       ## If the previous step passed, push the verified commit directly to the next branch
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: refs/heads/${{ needs.get-branch-names.outputs.next-branch }}
@@ -74,14 +74,14 @@ jobs:
       ## First, we'll checkout the repository. We don't persist credentials because we need a
       ## Personal Access Token to push on a branch that is protected. See
       ## https://github.com/cycjimmy/semantic-release-action#basic-usage
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Needed to do merges
 
       - uses: Workday/canvas-kit-actions/install@v2
         with:
-          node_version: 22.x
+          node_version: 24.x
 
       ## Configure git so the forward-merge script can create a merge commit.
       ## We'll make that user be the github-actions user.
@@ -100,7 +100,7 @@ jobs:
 
       ## Push both the commit and tag created by Lerna's version command using a PAT
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: refs/heads/${{ needs.get-branch-names.outputs.next-branch }}
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       ## If we've failed any previous step, we'll need to create a PR instead
-      - uses: NicholasBoll/action-forward-merge-pr@main
+      - uses: NicholasBoll/action-forward-merge-pr@89b33d1968555fb5d6a5814b4ab78221e47c37ab # v1.1.1
         with:
           token: ${{secrets.GH_RW_TOKEN}} # use PAT to force GH Actions to run the PR verify. The regular token will not
           branches: main+prerelease/minor,prerelease/minor+prerelease/major

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Set tokens artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: tokens-base
           path: tokens/
@@ -24,9 +24,9 @@ jobs:
       tokens: ${{ steps.artifact.outputs.artifact-id }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
@@ -41,7 +41,7 @@ jobs:
 
       - name: Set artifact
         id: artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: exported-tokens
           path: export
@@ -52,13 +52,13 @@ jobs:
     if: ${{ needs.build.outputs.tokens }}
     steps:
       - name: Checkout canvas-tokens repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Workday/canvas-tokens
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
@@ -67,7 +67,7 @@ jobs:
         run: yarn
 
       - name: Download exported tokens
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: exported-tokens
           path: packages/canvas-tokens/tokens
@@ -76,7 +76,7 @@ jobs:
         run: yarn build:tokens
         
       - name: Set dist tokens artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: web-tokens-files
           path: |
@@ -86,7 +86,11 @@ jobs:
   check-deprecated-tokens:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
 
       - name: Check deprecated folders organization
         id: check-deprecated
@@ -104,10 +108,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: get-baseline
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
 
       - name: Get tokens
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: tokens-base
           path: tokens-base/
@@ -125,7 +133,7 @@ jobs:
 
       - name: Comment PR with Markdown report
         if: steps.check-for-removals.outputs.result != ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: ${{ steps.check-for-removals.outputs.result }}
           comment-tag: removals
@@ -136,10 +144,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: get-baseline
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
 
       - name: Get tokens
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: tokens-base
           path: tokens-base/
@@ -154,7 +166,7 @@ jobs:
 
       - name: Comment PR with Markdown report
         if: steps.visual_report.outputs.content != ''
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: ${{ steps.visual_report.outputs.content }}
           comment-tag: visual-regression

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync-tokens.yml
+++ b/.github/workflows/sync-tokens.yml
@@ -15,12 +15,12 @@ jobs:
       tokens: ${{ steps.artifact.outputs.artifact-id }}
       message: ${{ steps.commit.outputs.message }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # Used for conventional commit ranges
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
@@ -44,7 +44,7 @@ jobs:
       - name: Set artifact
         if: ${{ !!steps.changed_files.outputs.changed }}
         id: artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: exported-tokens
           path: export
@@ -63,7 +63,7 @@ jobs:
       has_diff: ${{ steps.check_staged.outputs.has_staged }}
     steps:
       - name: Checkout canvas-tokens repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Workday/canvas-tokens
           persist-credentials: false
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Download exported tokens
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: exported-tokens
           path: packages/canvas-tokens/tokens
@@ -115,7 +115,7 @@ jobs:
 
       - name: Push changes
         if: ${{ steps.check_staged.outputs.has_staged == 'true' }}
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: ${{ steps.sync_branch.outputs.name }}
@@ -125,7 +125,7 @@ jobs:
       - name: Create Pull Request
         id: create-pull-request
         if: ${{ steps.check_staged.outputs.has_staged == 'true' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         continue-on-error: true
         with:
           github-token: ${{ secrets.GH_RW_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
     needs: sync-tokens
     if: ${{ needs.sync-tokens.result == 'success' && needs.sync-tokens.outputs.has_diff == 'true' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -164,7 +164,7 @@ jobs:
           git commit --allow-empty -m "chore: Sync tokens for ${{ github.ref_name }} branch"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GH_RW_TOKEN }}
           branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Issue

Resolves #142 

## Overview

This PR bumps everything to explicitly use Node 24 and pins external actions to commit SHA1s. `Workday/canvas-kit-actions` left at `@v2`.

| Action | SHA1 | Version |
|--------|------|---------|
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | v7.0.0 |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `actions/upload-artifact` | `bbbca2ddaa5d8feaa63e36b76fdaad77386f024f` | v7.0.0 |
| `actions/download-artifact` | `37930b1c2abaa49bbe596cd826c3c89aef350131` | v7.0.0 |
| `actions/github-script` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | v7.1.0 |
| `ad-m/github-push-action` | `881a6320fdb16eb5318c5054f31c218aec2b324c` | v1.3.0 |
| `NicholasBoll/action-forward-merge-pr` | `89b33d1968555fb5d6a5814b4ab78221e47c37ab` | v1.1.1 |
| `thollander/actions-comment-pull-request` | `24bffb9b452ba05a4f3f77933840a6a841d1b32b` | v3.0.1 |

## Checks

- [ ] Overview Added
- [ ] Deprecated tokens placed in `deprecated` folder
- [ ] Deprecated tokens file structure is the same as main.
- [ ] Main tokens file doesn't have deprecated tokens.
- [ ] Math values have spaces around math sign.

## Thank You Gif

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer: -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
