### PR TITLE
feat: remove selected colors from sana.json and update focus and border brand colors

### DIFF
--- a/tokens/sys/brand/canvas.json
+++ b/tokens/sys/brand/canvas.json
@@ -547,7 +547,7 @@
     },
     "common": {
       "focus": {
-        "value": "{base.blue.500}",
+        "value": "{palette.blue.500}",
         "type": "color",
         "deprecatedValues": {"v3": "brand.common.focus-outline"}
       },

--- a/tokens/sys/brand/canvas.json
+++ b/tokens/sys/brand/canvas.json
@@ -547,7 +547,7 @@
     },
     "common": {
       "focus": {
-        "value": "{brand.primary.500}",
+        "value": "{base.blue.500}",
         "type": "color",
         "deprecatedValues": {"v3": "brand.common.focus-outline"}
       },

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -270,7 +270,7 @@
     "brand": {
       "focus": {
         "primary": {
-          "value": "{brand.primary.500}",
+          "value": "{base.blue.500}",
           "type": "color",
           "description": "Tenant-themeable focus ring for interactive elements",
           "deprecatedValues": {"v3": "brand.common.focus-outline"}
@@ -457,7 +457,7 @@
       },
       "border": {
         "primary": {
-          "value": "{brand.primary.500}",
+          "value": "{base.blue.500}",
           "type": "color",
           "description": "Tenant-themeable primary border for focused inputs",
           "deprecatedValues": {}

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -270,7 +270,7 @@
     "brand": {
       "focus": {
         "primary": {
-          "value": "{base.palette.blue.500}",
+          "value": "{palette.blue.500}",
           "type": "color",
           "description": "Tenant-themeable focus ring for interactive elements",
           "deprecatedValues": {"v3": "brand.common.focus-outline"}
@@ -457,7 +457,7 @@
       },
       "border": {
         "primary": {
-          "value": "{base.palette.blue.500}",
+          "value": "{palette.blue.500}",
           "type": "color",
           "description": "Tenant-themeable primary border for focused inputs",
           "deprecatedValues": {}

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -270,7 +270,7 @@
     "brand": {
       "focus": {
         "primary": {
-          "value": "{base.blue.500}",
+          "value": "{base.palette.blue.500}",
           "type": "color",
           "description": "Tenant-themeable focus ring for interactive elements",
           "deprecatedValues": {"v3": "brand.common.focus-outline"}
@@ -457,7 +457,7 @@
       },
       "border": {
         "primary": {
-          "value": "{base.blue.500}",
+          "value": "{base.palette.blue.500}",
           "type": "color",
           "description": "Tenant-themeable primary border for focused inputs",
           "deprecatedValues": {}

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1846,7 +1846,6 @@
           "primary": {
             "value": "{base.palette.blue.500}",
             "type": "color",
-
             "description": "Tenant-themeable primary border for focused inputs"
           }
         },

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1813,12 +1813,6 @@
         }
       },
       "brand": {
-        "surface": {
-          "selected": {
-            "value": "{brand.neutral.A100}",
-            "type": "color"
-          }
-        },
         "accent": {
           "primary": {
             "value": "{brand.neutral.975}",
@@ -1861,11 +1855,6 @@
               "type": "color",
               "description": "Stronger tenant-themeable primary text and icon color"
             }
-          },
-          "selected": {
-            "value": "{brand.neutral.A900}",
-            "type": "color",
-            "description": "Tenant-themeable text color for selected items"
           },
           "link": {
             "default": {

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1825,6 +1825,13 @@
             "description": "Tenant-themeable primary action color for CTAs"
           }
         },
+        "focus": {
+          "primary": {
+            "value": "{base.palette.blue.500}",
+            "type": "color",
+            "description": "Tenant-themeable focus ring for interactive elements"
+          }
+        },
         "border": {
           "caution": {
             "value": "{brand.caution.500}",


### PR DESCRIPTION
## Overview

Removes `surface.selected` and `fg.selected` from sana.json theme to align with customer feedback around the global sidenav.

Update focus and border primary colors to point to base.blue color

