### PR TITLE
fix: Use black color for oklch

### DIFF
--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -2010,72 +2010,72 @@
         },
         "1": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.03)",
+            "value": "oklch(0 0 0 / 0.03)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.02)",
+            "value": "oklch(0 0 0 / 0.02)",
             "type": "color",
             "deprecatedValues": {}
           }
         },
         "2": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.05)",
+            "value": "oklch(0 0 0 / 0.05)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.0334)",
+            "value": "oklch(0 0 0 / 0.0334)",
             "type": "color",
             "deprecatedValues": {}
           }
         },
         "3": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.07)",
+            "value": "oklch(0 0 0 / 0.07)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.0467)",
+            "value": "oklch(0 0 0 / 0.0467)",
             "type": "color",
             "deprecatedValues": {}
           }
         },
         "4": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.09)",
+            "value": "oklch(0 0 0 / 0.09)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.06)",
+            "value": "oklch(0 0 0 / 0.06)",
             "type": "color",
             "deprecatedValues": {}
           }
         },
         "5": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.11)",
+            "value": "oklch(0 0 0 / 0.11)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.0734)",
+            "value": "oklch(0 0 0 / 0.0734)",
             "type": "color",
             "deprecatedValues": {}
           }
         },
         "6": {
           "key": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.13)",
+            "value": "oklch(0 0 0 / 0.13)",
             "type": "color",
             "deprecatedValues": {}
           },
           "ambient": {
-            "value": "oklch({sys.color.shadow.base.light} / 0.0867)",
+            "value": "oklch(0 0 0 / 0.0867)",
             "type": "color",
             "deprecatedValues": {}
           }


### PR DESCRIPTION
## Issue

<!-- Provide an issue # if one exists -->

## Overview

<!-- Give a brief description of what this PR does. -->

## Checks

- [ ] Overview Added
- [ ] Deprecated tokens placed in `deprecated` folder
- [ ] Deprecated tokens file structure is the same as main.
- [ ] Main tokens file doesn't have deprecated tokens.
- [ ] Math values have spaces around math sign.

## Thank You Gif

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer: -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
