### PR TITLE
feat: add fg link tokens

### DIFF
--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -605,6 +605,18 @@
           "deprecatedValues": {}
         }
       },
+      "link": {
+        "default": {
+          "value": "{palette.blue.600}",
+          "type": "color",
+          "description": "Default text color for hyperlinks"
+        },
+        "hover": {
+          "value": "{palette.blue.700}",
+          "type": "color",
+          "description": "Text color for hyperlinks on hover"
+        }
+      },
       "ai": {
         "value": "{palette.blue.950}",
         "type": "color",

--- a/tokens/sys/color/color.json
+++ b/tokens/sys/color/color.json
@@ -609,7 +609,7 @@
         "default": {
           "value": "{palette.blue.600}",
           "type": "color",
-          "description": "Default text color for hyperlinks"
+          "description": "Default text color for hyperlinks (not tenant themeable)"
         },
         "hover": {
           "value": "{palette.blue.700}",

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1922,6 +1922,18 @@
           "value": "{base.palette.neutral.A400}",
           "type": "color",
           "description": "Disabled state text and icons"
+        },
+        "link": {
+          "default": {
+            "value": "{base.palette.blue.600}",
+            "type": "color",
+            "description": "Default text color for hyperlinks"
+          },
+          "hover": {
+            "value": "{base.palette.blue.700}",
+            "type": "color",
+            "description": "Text color for hyperlinks on hover"
+          }
         }
       },
       "border": {
@@ -2129,18 +2141,6 @@
               "value": "{brand.neutral.A950}",
               "type": "color",
               "description": "Stronger tenant-themeable primary text and icon color"
-            }
-          },
-          "link": {
-            "default": {
-              "value": "{base.palette.blue.600}",
-              "type": "color",
-              "description": "Default text color for hyperlinks"
-            },
-            "hover": {
-              "value": "{base.palette.blue.700}",
-              "type": "color",
-              "description": "Text color for hyperlinks on hover"
             }
           }
         }


### PR DESCRIPTION
## Summary
- Add `color.fg.link.default` and `color.fg.link.hover` to sys color (blue-600 / blue-700)
- Add matching tokens under `sys.color.fg` in sana theme
- Remove misplaced link tokens from `sys.color.brand.fg`