### PR TITLE
feat: Update font tokens under Sana theme

### DIFF
--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1626,6 +1626,10 @@
       "default": {
         "value": "\"Sana Sans VF\", {sys.font-family.fallback}",
         "type": "text"
+      },
+      "mono": {
+        "value": "\"IBM Plex Mono\", \"Roboto Mono\", monospace",
+        "type": "text"
       }
     },
     "line-height": {

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1624,11 +1624,11 @@
         "type": "text"
       },
       "default": {
-        "value": "\"Sana Sans VF\", {sys.font-family.fallback}",
+        "value": "{base.font-family.50}, {sys.font-family.fallback}",
         "type": "text"
       },
       "mono": {
-        "value": "\"IBM Plex Mono\", \"Roboto Mono\", monospace",
+        "value": "{base.font-family.100}, \"Roboto Mono\", monospace",
         "type": "text"
       }
     },

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1361,7 +1361,7 @@
     },
     "font-family": {
       "0": {
-        "value": "-apple-system, BlinkMacSystemFont, \"Sana Serif\", Roboto, Inter, system-ui, sans-serif, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+        "value": "Roboto, -apple-system, BlinkMacSystemFont, \"Sana Serif\", Inter, system-ui, sans-serif, Avenir, Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
         "type": "text"
       },
       "50": {

--- a/tokens/theme/sana.json
+++ b/tokens/theme/sana.json
@@ -1365,7 +1365,7 @@
         "type": "text"
       },
       "50": {
-        "value": "Sana Sans LCG 05 VF",
+        "value": "Sana Sans VF",
         "type": "text"
       },
       "100": {
@@ -1621,6 +1621,10 @@
     "font-family": {
       "fallback": {
         "value": "{base.font-family.0}",
+        "type": "text"
+      },
+      "default": {
+        "value": "\"Sana Sans VF\", {sys.font-family.fallback}",
         "type": "text"
       }
     },


### PR DESCRIPTION
## Issue

## Overview

Sets up Sana Sans as the default font family & IBM Plex Mono as the monospace font under the Sana theme.

Also renames the Sana Sans font as using numbers in it makes it tricky to use with Emotion (requires inner quotes).

## Checks

- [ ] Overview Added
- [ ] Deprecated tokens placed in `deprecated` folder
- [ ] Deprecated tokens file structure is the same as main.
- [ ] Main tokens file doesn't have deprecated tokens.
- [ ] Math values have spaces around math sign.

## Thank You Gif

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer: -->

<!-- ![](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
